### PR TITLE
feat: Add core JPA entities (User, Group, Schedule, Board, Notice, Poll)

### DIFF
--- a/src/main/java/com/moau/moau/board/Board.java
+++ b/src/main/java/com/moau/moau/board/Board.java
@@ -1,0 +1,22 @@
+package com.moau.moau.board;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.group.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "BOARDS")
+public class Board extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/com/moau/moau/board/BoardPost.java
+++ b/src/main/java/com/moau/moau/board/BoardPost.java
@@ -1,0 +1,36 @@
+package com.moau.moau.board;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "BOARD_POSTS")
+public class BoardPost extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob // MEDIUMTEXT, LONGTEXT 등 대용량 텍스트를 위한 어노테이션
+    @Column(nullable = false)
+    private String body;
+
+    // @Enumerated(EnumType.STRING)
+    private String status; // ENUM 타입
+
+    @Column(name = "is_pinned", nullable = false)
+    private Boolean isPinned = false; // 기본값을 false로 설정
+}

--- a/src/main/java/com/moau/moau/board/PostComment.java
+++ b/src/main/java/com/moau/moau/board/PostComment.java
@@ -1,0 +1,43 @@
+package com.moau.moau.board;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "POST_COMMENTS")
+public class PostComment extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private BoardPost boardPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id") // 자기 자신을 참조. 최상위 댓글은 null.
+    private PostComment parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false)
+    private Integer depth; // 0: 최상위 댓글, 1: 대댓글, 2: 대대댓글
+
+    @Column(length = 1000)
+    private String path; // 댓글의 계층 구조를 표현. 예: "1/5/12/"
+
+    @Lob
+    @Column(nullable = false)
+    private String body;
+
+    // @Enumerated(EnumType.STRING)
+    private String status;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/com/moau/moau/group/Group.java
+++ b/src/main/java/com/moau/moau/group/Group.java
@@ -1,0 +1,28 @@
+package com.moau.moau.group;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "GROUPS")
+public class Group extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_user_id", nullable = false)
+    private User owner;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "invite_code", length = 8, unique = true)
+    private String inviteCode;
+}

--- a/src/main/java/com/moau/moau/group/GroupMember.java
+++ b/src/main/java/com/moau/moau/group/GroupMember.java
@@ -1,0 +1,47 @@
+package com.moau.moau.group;
+
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "GROUP_MEMBERS")
+public class GroupMember {
+
+    @EmbeddedId // 위에서 만든 복합키 클래스를 ID로 사용
+    private GroupMemberId id;
+
+    @MapsId("groupId") // 복합키의 groupId 필드를 실제 Group 엔티티와 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @MapsId("userId") // 복합키의 userId 필드를 실제 User 엔티티와 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    // @Enumerated(EnumType.STRING)
+    private String role; // ENUM 타입
+
+    @Column(nullable = false)
+    // @Enumerated(EnumType.STRING)
+    private String status; // ENUM 타입
+
+    @Column(name = "joined_at", nullable = false)
+    private Instant joinedAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    // updatedBy는 User 엔티티와 관계를 맺을 수도 있고, Long 타입으로 ID만 저장할 수도 있습니다.
+    // 여기서는 ID만 저장하는 방식으로 구현했습니다.
+    private Long updatedBy;
+}

--- a/src/main/java/com/moau/moau/group/GroupMemberId.java
+++ b/src/main/java/com/moau/moau/group/GroupMemberId.java
@@ -1,0 +1,18 @@
+package com.moau.moau.group;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable // 이 클래스가 다른 엔티티에 포함될 수 있음을 의미
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode // 복합키는 equals와 hashCode를 구현해야 합니다.
+public class GroupMemberId implements Serializable {
+
+    private Long groupId;
+    private Long userId;
+
+}

--- a/src/main/java/com/moau/moau/group/JoinRequest.java
+++ b/src/main/java/com/moau/moau/group/JoinRequest.java
@@ -1,0 +1,39 @@
+package com.moau.moau.group;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "JOIN_REQUESTS")
+public class JoinRequest extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_user_id", nullable = false)
+    private User requestUser;
+
+    @Column(nullable = false)
+    // @Enumerated(EnumType.STRING)
+    private String status; // ENUM 타입 (예: PENDING, APPROVED, REJECTED)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decided_by")
+    private User decidedBy; // 요청을 승인/거절한 관리자
+
+    // BaseId가 createdAt, updatedAt을 이미 가지고 있으므로,
+    // ERD의 requested_at은 createdAt으로 대체하고 decided_at만 추가합니다.
+    @Column(name = "decided_at")
+    private Instant decidedAt;
+
+}

--- a/src/main/java/com/moau/moau/notice/Notice.java
+++ b/src/main/java/com/moau/moau/notice/Notice.java
@@ -1,0 +1,43 @@
+package com.moau.moau.notice;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.group.Group;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "NOTICES")
+public class Notice extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String body;
+
+    @Column(name = "is_pinned", nullable = false)
+    private Boolean isPinned = false;
+
+    // @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private String status;
+
+    @Column(name = "published_at")
+    private Instant publishedAt; // 게시 시각
+}

--- a/src/main/java/com/moau/moau/poll/Poll.java
+++ b/src/main/java/com/moau/moau/poll/Poll.java
@@ -1,0 +1,34 @@
+package com.moau.moau.poll;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.notice.Notice;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "POLLS")
+public class Poll extends BaseId {
+
+    // Poll은 Notice에 1:1로 종속되는 관계
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User creator;
+
+    // @Enumerated(EnumType.STRING)
+    @Column(name = "result_visibility", nullable = false)
+    private String resultVisibility; // 결과 공개 여부
+
+    @Column(name = "closes_at")
+    private Instant closesAt; // 투표 마감 시각
+}

--- a/src/main/java/com/moau/moau/poll/PollResponse.java
+++ b/src/main/java/com/moau/moau/poll/PollResponse.java
@@ -1,0 +1,39 @@
+package com.moau.moau.poll;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "POLL_RESPONSES")
+public class PollResponse extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id", nullable = false)
+    private Poll poll;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "respondent_user_id", nullable = false)
+    private User respondent;
+
+    @Column(name = "anon_identity", length = 8)
+    private String anonIdentity;
+
+    // @Enumerated(EnumType.STRING)
+    @Column(name = "response_type")
+    private String responseType;
+
+    @Column(name = "value_text", columnDefinition = "TEXT")
+    private String valueText;
+
+    @Column(name = "value_bool")
+    private Boolean valueBool;
+
+    @Column(name = "value_int")
+    private Integer valueInt;
+}

--- a/src/main/java/com/moau/moau/schedule/Schedule.java
+++ b/src/main/java/com/moau/moau/schedule/Schedule.java
@@ -1,0 +1,43 @@
+package com.moau.moau.schedule;
+
+import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.group.Group; // Group 엔티티 import
+import com.moau.moau.user.User;   // User 엔티티 import
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "SCHEDULES")
+public class Schedule extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User creator;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "starts_at", nullable = false)
+    private Instant startsAt;
+
+    @Column(name = "ends_at", nullable = false)
+    private Instant endsAt;
+
+    private String location;
+
+    @Column(name = "recurring_id", length = 36)
+    private String recurringId;
+}

--- a/src/main/java/com/moau/moau/user/User.java
+++ b/src/main/java/com/moau/moau/user/User.java
@@ -1,0 +1,27 @@
+package com.moau.moau.user;
+
+import com.moau.moau.global.domain.BaseSoftDelete;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA는 기본 생성자를 필요로 합니다.
+@Entity
+@Table(name = "USERS")
+public class User extends BaseSoftDelete {
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    // ERD의 status 컬럼 예시. 실제 Enum 클래스는 별도로 정의해야 합니다.
+    // @Enumerated(EnumType.STRING)
+    // @Column(nullable = false)
+    // private UserStatus status;
+}


### PR DESCRIPTION
- resolves #1
---
### 📌 요약
- 확정된 ERD 설계를 바탕으로 프로젝트의 핵심 도메인(유저, 그룹, 일정, 게시판 등)에 대한 JPA 엔티티 클래스들을 생성했습니다.
- 이를 통해 다른 백엔드 개발자들이 각자 맡은 기능 개발을 시작할 수 있는 데이터베이스 뼈대를 마련합니다.

### ✅ 작업 내용
- 공통 엔티티 기반 클래스(`BaseId`, `BaseSoftDelete` 등) 구조에 맞춰 엔티티를 작성했습니다.
- User 엔티티에 소프트 삭제(Soft Delete) 및 시간 자동 생성을 위한 Auditing 기능을 적용했습니다.
- **생성된 엔티티 목록:**
  - `User`
  - `Group`, `GroupMember`
  - `JoinRequest`
  - `Schedule`
  - `Board`, `BoardPost`, `PostComment`
  - `Notice`, `Poll`, `PollResponse`

### 📚 참고 자료, 할 말
- 회계(Transaction, Receipt 등) 및 인증(RefreshToken) 관련 엔티티는 각 기능 담당자가 직접 구현하기로 하여 이번 작업에서 제외했습니다.
- 이제 백엔드의 뼈대가 잡혔으니, 다 같이 빠르게 기능 개발을 시작해봐요! 🔥