### PR TITLE
[feature] 회비(Dues) 관리 도메인 구현 및 뱅킹 연동 완료

### DIFF
--- a/src/main/java/com/moau/moau/accounting/banking/service/BankingCommandService.java
+++ b/src/main/java/com/moau/moau/accounting/banking/service/BankingCommandService.java
@@ -78,33 +78,57 @@ public class BankingCommandService {
     public void recordExpense(Long teamId, Long bankAccountId, Long amountCents, Long categoryId,
                               String description, LocalDate transactionDate, Long reviewId) {
 
-        // 1. 계좌, 카테고리, 팀 유효성 검증
-        BankAccount account = bankAccountRepository.findById(bankAccountId)
+        BankAccount account = bankAccountRepository.findByIdAndTeamId(bankAccountId, teamId)
                 .orElseThrow(() -> new BusinessException(BankingError.ACCOUNT_NOT_FOUND));
 
-        if (!account.getTeamId().equals(teamId)) {
-            throw new BusinessException(BankingError.ACCOUNT_NOT_FOUND);
-        }
-
-        Category category = categoryRepository.findByIdAndTeamId(categoryId, teamId)
+        categoryRepository.findByIdAndTeamId(categoryId, teamId)
                 .orElseThrow(() -> new BusinessException(CategoryError.NOT_FOUND));
 
-        // 2. BANK_TRANSACTIONS 에 지출(음수) 내역 INSERT
         BankTransaction expense = BankTransaction.builder()
                 .bankAccount(account)
                 .txnDate(transactionDate)
-                .amountCents(amountCents * -1) // 지출이므로 음수로 변환
+                .amountCents(amountCents * -1)
                 .description(description)
                 .build();
         bankTransactionRepository.save(expense);
 
-        // 3. BANK_BALANCES 의 최신 잔액 UPDATE (차감)
+        // 4. 잔액 차감
+        updateBalance(account, amountCents * -1);
+    }
+
+    @Transactional
+    public void recordIncome(Long teamId, Long bankAccountId, Long amountCents, Long categoryId,
+                             String description, LocalDate transactionDate) {
+
+        // 1. 계좌 소유권 검증
+        BankAccount account = bankAccountRepository.findByIdAndTeamId(bankAccountId, teamId)
+                .orElseThrow(() -> new BusinessException(BankingError.ACCOUNT_NOT_FOUND));
+
+        // 2. 카테고리 검증
+        categoryRepository.findByIdAndTeamId(categoryId, teamId)
+                .orElseThrow(() -> new BusinessException(CategoryError.NOT_FOUND));
+
+        // 3. 수입 내역 기록 (양수 저장)
+        BankTransaction income = BankTransaction.builder()
+                .bankAccount(account)
+                .txnDate(transactionDate)
+                .amountCents(amountCents) // 양수
+                .description(description)
+                .build();
+        bankTransactionRepository.save(income);
+
+        // 4. 잔액 증가
+        updateBalance(account, amountCents);
+    }
+
+    // (공통) 잔액 업데이트 로직 분리
+    private void updateBalance(BankAccount account, Long amountDelta) {
         BankBalance latestBalance = bankBalanceRepository.findTopByBankAccountOrderByAsOfDesc(account)
                 .orElseThrow(() -> new BusinessException(BankingError.ACCOUNT_NOT_FOUND, "계좌의 잔액 정보가 없습니다."));
 
         BankBalance updatedBalance = BankBalance.builder()
                 .bankAccount(account)
-                .balanceCents(latestBalance.getBalanceCents() - amountCents) // 잔액 차감
+                .balanceCents(latestBalance.getBalanceCents() + amountDelta) // (기존 잔액 + 변동액)
                 .currency("KRW")
                 .asOf(Instant.now())
                 .build();

--- a/src/main/java/com/moau/moau/accounting/dues/controller/DuesController.java
+++ b/src/main/java/com/moau/moau/accounting/dues/controller/DuesController.java
@@ -1,0 +1,59 @@
+package com.moau.moau.accounting.dues.controller;
+
+import com.moau.moau.accounting.dues.dto.request.DuesStatusUpdateRequestDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDetailDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDto;
+import com.moau.moau.accounting.dues.service.DuesCommandService;
+import com.moau.moau.accounting.dues.service.DuesQueryService;
+import com.moau.moau.global.payload.ResponseDto;
+import com.moau.moau.global.security.CheckTeamRole;
+import com.moau.moau.team.domain.TeamMemberRole;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class DuesController implements DuesControllerSwagger {
+
+    private final DuesQueryService duesQueryService;
+    private final DuesCommandService duesCommandService;
+
+    @Override
+    @CheckTeamRole(TeamMemberRole.ADMIN)
+    public ResponseEntity<ResponseDto<List<DuesCycleDto>>> getCycles(
+            @PathVariable Long teamId
+    ) {
+        List<DuesCycleDto> response = duesQueryService.getCycles(teamId);
+        return ResponseEntity.ok(ResponseDto.data(response));
+    }
+
+    @Override
+    @CheckTeamRole(TeamMemberRole.ADMIN)
+    public ResponseEntity<ResponseDto<DuesCycleDetailDto>> getCycleStatus(
+            @PathVariable Long teamId,
+            @RequestParam LocalDate targetDate
+    ) {
+        DuesCycleDetailDto response = duesQueryService.getCycleStatus(teamId, targetDate);
+        return ResponseEntity.ok(ResponseDto.data(response));
+    }
+
+    @Override
+    @CheckTeamRole(TeamMemberRole.ADMIN)
+    public ResponseEntity<ResponseDto<DuesCycleDetailDto>> updateMemberStatus(
+            @PathVariable Long teamId,
+            @PathVariable Long cycleId,
+            @PathVariable Long userId,
+            @Valid @RequestBody DuesStatusUpdateRequestDto requestDto
+    ) {
+        DuesCycleDetailDto response = duesCommandService.updateMemberStatus(teamId, cycleId, userId, requestDto);
+        return ResponseEntity.ok(ResponseDto.data(response));
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/dues/controller/DuesControllerSwagger.java
+++ b/src/main/java/com/moau/moau/accounting/dues/controller/DuesControllerSwagger.java
@@ -1,0 +1,55 @@
+package com.moau.moau.accounting.dues.controller;
+
+import com.moau.moau.accounting.dues.dto.request.DuesStatusUpdateRequestDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDetailDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDto;
+import com.moau.moau.global.exception.ErrorResponse;
+import com.moau.moau.global.payload.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "💸 Accounting - Dues", description = "회비 관리 (납부 주기, 현황, 체크) API")
+@RequestMapping("/api/teams/{teamId}/accounting/dues")
+public interface DuesControllerSwagger {
+
+    @Operation(summary = "회비 주기 목록 조회", description = "(Auth: ADMIN) 팀 설정에 따른 회비 납부 주기(월/분기 등) 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/cycles")
+    ResponseEntity<ResponseDto<List<DuesCycleDto>>> getCycles(
+            @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId
+    );
+
+    @Operation(summary = "특정 주기 납부 현황 조회", description = "(Auth: ADMIN) 특정 날짜가 포함된 주기의 납부 현황을 조회합니다. (데이터가 없으면 자동 생성)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "팀 회비 설정이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/cycles/status")
+    ResponseEntity<ResponseDto<DuesCycleDetailDto>> getCycleStatus(
+            @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId,
+            @Parameter(description = "조회할 날짜 (YYYY-MM-DD)", example = "2025-11-20")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
+    );
+
+    @Operation(summary = "납부 상태 변경 (체크/해제)", description = "(Auth: ADMIN) 특정 멤버의 납부 상태를 변경하고 뱅킹 내역을 기록합니다.")
+    @ApiResponse(responseCode = "200", description = "변경 성공 (갱신된 전체 현황 반환)")
+    @PatchMapping("/cycles/{cycleId}/members/{userId}/status")
+    ResponseEntity<ResponseDto<DuesCycleDetailDto>> updateMemberStatus(
+            @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId,
+            @Parameter(description = "회비 주기 ID", required = true) @PathVariable Long cycleId,
+            @Parameter(description = "대상 멤버 User ID", required = true) @PathVariable Long userId,
+            @Valid @RequestBody DuesStatusUpdateRequestDto requestDto
+    );
+}

--- a/src/main/java/com/moau/moau/accounting/dues/domain/DuesCycle.java
+++ b/src/main/java/com/moau/moau/accounting/dues/domain/DuesCycle.java
@@ -1,0 +1,35 @@
+package com.moau.moau.accounting.dues.domain;
+
+import com.moau.moau.global.domain.BaseId;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "dues_cycles", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"team_id", "start_date", "end_date"})
+})
+public class DuesCycle extends BaseId {
+
+    @Column(name = "team_id", nullable = false)
+    private Long teamId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Builder
+    public DuesCycle(Long teamId, String name, LocalDate startDate, LocalDate endDate) {
+        this.teamId = teamId;
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/dues/domain/DuesMemberStatus.java
+++ b/src/main/java/com/moau/moau/accounting/dues/domain/DuesMemberStatus.java
@@ -1,0 +1,48 @@
+package com.moau.moau.accounting.dues.domain;
+
+import com.moau.moau.global.domain.BaseId;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "dues_member_statuses")
+public class DuesMemberStatus extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cycle_id", nullable = false)
+    private DuesCycle cycle;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DuesStatus status;
+
+    @Column(name = "paid_at")
+    private Instant paidAt;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Builder
+    public DuesMemberStatus(DuesCycle cycle, Long userId, Long amount) {
+        this.cycle = cycle;
+        this.userId = userId;
+        this.status = DuesStatus.UNPAID;
+        this.amount = amount;
+    }
+
+    public void markPaid() {
+        this.status = DuesStatus.PAID;
+        this.paidAt = Instant.now();
+    }
+
+    public void markUnpaid() {
+        this.status = DuesStatus.UNPAID;
+        this.paidAt = null;
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/dues/domain/DuesStatus.java
+++ b/src/main/java/com/moau/moau/accounting/dues/domain/DuesStatus.java
@@ -1,0 +1,5 @@
+package com.moau.moau.accounting.dues.domain;
+
+public enum DuesStatus {
+    PAID, UNPAID
+}

--- a/src/main/java/com/moau/moau/accounting/dues/dto/request/DuesStatusUpdateRequestDto.java
+++ b/src/main/java/com/moau/moau/accounting/dues/dto/request/DuesStatusUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.moau.moau.accounting.dues.dto.request;
+
+import com.moau.moau.accounting.dues.domain.DuesStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record DuesStatusUpdateRequestDto(
+        @NotNull(message = "변경할 상태 값은 필수입니다.")
+        DuesStatus status,
+
+        @NotNull(message = "입금받을(또는 취소할) 은행 계좌 ID는 필수입니다.")
+        Long bankAccountId,
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Long categoryId,
+
+        String memo
+) {
+}

--- a/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesCycleDetailDto.java
+++ b/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesCycleDetailDto.java
@@ -1,0 +1,20 @@
+package com.moau.moau.accounting.dues.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DuesCycleDetailDto(
+        Long cycleId,
+        String cycleName,
+        LocalDate startDate,
+        LocalDate endDate,
+
+        List<DuesMemberDto> paidMembers,
+        List<DuesMemberDto> unpaidMembers,
+
+        int totalMemberCount,
+        int paidCount,
+        long totalExpectedAmount,
+        long totalCollectedAmount
+) {
+}

--- a/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesCycleDto.java
+++ b/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesCycleDto.java
@@ -1,0 +1,21 @@
+package com.moau.moau.accounting.dues.dto.response;
+
+import com.moau.moau.accounting.dues.domain.DuesCycle;
+
+import java.time.LocalDate;
+
+public record DuesCycleDto(
+        Long cycleId,
+        String name,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static DuesCycleDto from(DuesCycle cycle) {
+        return new DuesCycleDto(
+                cycle.getId(),
+                cycle.getName(),
+                cycle.getStartDate(),
+                cycle.getEndDate()
+        );
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesMemberDto.java
+++ b/src/main/java/com/moau/moau/accounting/dues/dto/response/DuesMemberDto.java
@@ -1,0 +1,14 @@
+package com.moau.moau.accounting.dues.dto.response;
+
+import com.moau.moau.accounting.dues.domain.DuesStatus;
+import java.time.Instant;
+
+public record DuesMemberDto(
+        Long userId,
+        String name,
+        DuesStatus status,
+        Long amount,
+        Instant paidAt,
+        String memo
+) {
+}

--- a/src/main/java/com/moau/moau/accounting/dues/repository/DuesCycleRepository.java
+++ b/src/main/java/com/moau/moau/accounting/dues/repository/DuesCycleRepository.java
@@ -1,0 +1,20 @@
+package com.moau.moau.accounting.dues.repository;
+
+import com.moau.moau.accounting.dues.domain.DuesCycle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DuesCycleRepository extends JpaRepository<DuesCycle, Long> {
+
+    // 1. 팀 ID와 시작 날짜로 이미 생성된 주기가 있는지 조회
+    Optional<DuesCycle> findByTeamIdAndStartDate(Long teamId, LocalDate startDate);
+
+    // 2. 팀의 모든 주기를 최신순으로 조회
+    List<DuesCycle> findAllByTeamIdOrderByStartDateDesc(Long teamId);
+
+    // 3. ID와 팀 ID 일치 여부 확인
+    Optional<DuesCycle> findByIdAndTeamId(Long id, Long teamId);
+}

--- a/src/main/java/com/moau/moau/accounting/dues/repository/DuesMemberStatusRepository.java
+++ b/src/main/java/com/moau/moau/accounting/dues/repository/DuesMemberStatusRepository.java
@@ -1,0 +1,25 @@
+package com.moau.moau.accounting.dues.repository;
+
+import com.moau.moau.accounting.dues.domain.DuesCycle;
+import com.moau.moau.accounting.dues.domain.DuesMemberStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DuesMemberStatusRepository extends JpaRepository<DuesMemberStatus, Long> {
+
+    // 1. 특정 주기의 모든 멤버 상태 조회
+    List<DuesMemberStatus> findAllByCycle(DuesCycle cycle);
+
+    // 2. 특정 주기 + 특정 유저의 상태 조회
+    Optional<DuesMemberStatus> findByCycleAndUserId(DuesCycle cycle, Long userId);
+
+    // 3. 특정 주기의 멤버 상태 일괄 삭제
+    @Modifying
+    @Query("DELETE FROM DuesMemberStatus d WHERE d.cycle = :cycle")
+    void deleteAllByCycle(@Param("cycle") DuesCycle cycle);
+}

--- a/src/main/java/com/moau/moau/accounting/dues/service/DuesCommandService.java
+++ b/src/main/java/com/moau/moau/accounting/dues/service/DuesCommandService.java
@@ -1,0 +1,78 @@
+package com.moau.moau.accounting.dues.service;
+
+import com.moau.moau.accounting.banking.service.BankingCommandService;
+import com.moau.moau.accounting.dues.domain.DuesCycle;
+import com.moau.moau.accounting.dues.domain.DuesMemberStatus;
+import com.moau.moau.accounting.dues.domain.DuesStatus;
+import com.moau.moau.accounting.dues.dto.request.DuesStatusUpdateRequestDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDetailDto;
+import com.moau.moau.global.exception.error.DuesError;
+import com.moau.moau.accounting.dues.repository.DuesCycleRepository;
+import com.moau.moau.accounting.dues.repository.DuesMemberStatusRepository;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.user.domain.User;
+import com.moau.moau.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DuesCommandService {
+
+    private final DuesCycleRepository duesCycleRepository;
+    private final DuesMemberStatusRepository duesMemberStatusRepository;
+    private final BankingCommandService bankingCommandService;
+    private final DuesQueryService duesQueryService;
+    private final UserRepository userRepository;
+
+    public DuesCycleDetailDto updateMemberStatus(Long teamId, Long cycleId, Long targetUserId, DuesStatusUpdateRequestDto req) {
+
+        // 1. 사이클 확인
+        DuesCycle cycle = duesCycleRepository.findByIdAndTeamId(cycleId, teamId)
+                .orElseThrow(() -> new BusinessException(DuesError.CYCLE_NOT_FOUND));
+
+        // 2. 멤버 상태 조회
+        DuesMemberStatus memberStatus = duesMemberStatusRepository.findByCycleAndUserId(cycle, targetUserId)
+                .orElseThrow(() -> new BusinessException(DuesError.MEMBER_STATUS_NOT_FOUND));
+
+        // 3. 변경 사항이 없으면 바로 리턴
+        if (memberStatus.getStatus() == req.status()) {
+            return duesQueryService.getCycleStatusById(teamId, cycleId);
+        }
+
+        String userName = userRepository.findById(targetUserId).map(User::getNickname).orElse("멤버");
+
+        // 4. 상태 변경 및 뱅킹 연동
+        if (req.status() == DuesStatus.PAID) {
+            memberStatus.markPaid();
+
+            bankingCommandService.recordIncome(
+                    teamId,
+                    req.bankAccountId(),
+                    memberStatus.getAmount(),
+                    req.categoryId(),
+                    String.format("%s 회비 납부 (%s)", cycle.getName(), userName),
+                    LocalDate.now()
+            );
+        } else {
+            memberStatus.markUnpaid();
+
+            bankingCommandService.recordExpense(
+                    teamId,
+                    req.bankAccountId(),
+                    memberStatus.getAmount(),
+                    req.categoryId(),
+                    String.format("%s 회비 납부 취소 (%s)", cycle.getName(), userName),
+                    LocalDate.now(),
+                    null
+            );
+        }
+
+        // 5. 최신 현황 반환 (전체 리스트)
+        return duesQueryService.getCycleStatusById(teamId, cycleId);
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/dues/service/DuesCycleCalculator.java
+++ b/src/main/java/com/moau/moau/accounting/dues/service/DuesCycleCalculator.java
@@ -1,0 +1,60 @@
+package com.moau.moau.accounting.dues.service;
+
+import com.moau.moau.global.exception.error.DuesError;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.team.domain.DuesPeriod;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class DuesCycleCalculator {
+
+    public CycleRange calculateCurrentRange(DuesPeriod period, LocalDate date) {
+        int year = date.getYear();
+        int month = date.getMonthValue();
+
+        return switch (period) {
+            case MONTHLY -> {
+                // 예: 2025-11-01 ~ 2025-11-30
+                LocalDate start = LocalDate.of(year, month, 1);
+                yield new CycleRange(
+                        String.format("%d년 %d월", year, month),
+                        start,
+                        start.plusMonths(1).minusDays(1)
+                );
+            }
+            case QUARTERLY -> {
+                // 예: 2025-10-01 ~ 2025-12-31 (4분기)
+                int quarter = (month - 1) / 3 + 1;
+                LocalDate start = LocalDate.of(year, (quarter - 1) * 3 + 1, 1);
+                yield new CycleRange(
+                        String.format("%d년 %d분기", year, quarter),
+                        start,
+                        start.plusMonths(3).minusDays(1)
+                );
+            }
+            case HALF_YEARLY -> {
+                int half = (month - 1) / 6 + 1;
+                LocalDate start = LocalDate.of(year, (half - 1) * 6 + 1, 1);
+                yield new CycleRange(
+                        String.format("%d년 %s반기", year, (half == 1 ? "상" : "하")),
+                        start,
+                        start.plusMonths(6).minusDays(1)
+                );
+            }
+            case YEARLY -> {
+                LocalDate start = LocalDate.of(year, 1, 1);
+                yield new CycleRange(
+                        String.format("%d년", year),
+                        start,
+                        start.plusMonths(12).minusDays(1)
+                );
+            }
+            case NONE -> throw new BusinessException(DuesError.TEAM_SETTING_NOT_FOUND, "회비 설정이 없는 팀입니다.");
+        };
+    }
+
+    public record CycleRange(String name, LocalDate start, LocalDate end) {}
+}

--- a/src/main/java/com/moau/moau/accounting/dues/service/DuesQueryService.java
+++ b/src/main/java/com/moau/moau/accounting/dues/service/DuesQueryService.java
@@ -1,0 +1,153 @@
+package com.moau.moau.accounting.dues.service;
+
+import com.moau.moau.accounting.dues.domain.DuesCycle;
+import com.moau.moau.accounting.dues.domain.DuesMemberStatus;
+import com.moau.moau.accounting.dues.domain.DuesStatus;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDetailDto;
+import com.moau.moau.accounting.dues.dto.response.DuesCycleDto;
+import com.moau.moau.accounting.dues.dto.response.DuesMemberDto;
+import com.moau.moau.global.exception.error.DuesError;
+import com.moau.moau.accounting.dues.repository.DuesCycleRepository;
+import com.moau.moau.accounting.dues.repository.DuesMemberStatusRepository;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.CommonError;
+import com.moau.moau.team.domain.DuesPeriod;
+import com.moau.moau.team.domain.Team;
+import com.moau.moau.team.domain.TeamMember;
+import com.moau.moau.team.domain.TeamMemberStatus;
+import com.moau.moau.team.repository.TeamMemberRepository;
+import com.moau.moau.team.repository.TeamRepository;
+import com.moau.moau.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DuesQueryService {
+
+    private final DuesCycleRepository duesCycleRepository;
+    private final DuesMemberStatusRepository duesMemberStatusRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final DuesCycleCalculator calculator;
+
+    // API 1: 회비 주기 목록 조회
+    @Transactional(readOnly = true)
+    public List<DuesCycleDto> getCycles(Long teamId) {
+        return duesCycleRepository.findAllByTeamIdOrderByStartDateDesc(teamId)
+                .stream()
+                .map(DuesCycleDto::from)
+                .toList();
+    }
+
+    // API 2: 특정 주기의 납부 현황 조회 (Lazy Loading 포함)
+    // * 트랜잭션이 readOnly = false 여야 합니다 (생성 로직 때문)
+    @Transactional
+    public DuesCycleDetailDto getCycleStatus(Long teamId, LocalDate targetDate) {
+        Team team = teamRepository.findByIdAndDeletedAtIsNull(teamId)
+                .orElseThrow(() -> new BusinessException(CommonError.TEAM_NOT_FOUND));
+
+        if (team.getDuesPeriod() == DuesPeriod.NONE) {
+            throw new BusinessException(DuesError.TEAM_SETTING_NOT_FOUND);
+        }
+
+        // 1. 타겟 날짜가 포함되는 주기 계산
+        DuesCycleCalculator.CycleRange range = calculator.calculateCurrentRange(team.getDuesPeriod(), targetDate);
+
+        // 2. DB 조회 -> 없으면 생성 (Lazy Loading)
+        DuesCycle cycle = duesCycleRepository.findByTeamIdAndStartDate(teamId, range.start())
+                .orElseGet(() -> createNewCycle(team, range));
+
+        // 3. 상세 DTO 변환
+        return createDetailDto(cycle);
+    }
+
+    // (Overloading) ID로 조회하는 경우
+    @Transactional(readOnly = true)
+    public DuesCycleDetailDto getCycleStatusById(Long teamId, Long cycleId) {
+        DuesCycle cycle = duesCycleRepository.findByIdAndTeamId(cycleId, teamId)
+                .orElseThrow(() -> new BusinessException(DuesError.CYCLE_NOT_FOUND));
+        return createDetailDto(cycle);
+    }
+
+    // --- Private Helpers ---
+
+    private DuesCycle createNewCycle(Team team, DuesCycleCalculator.CycleRange range) {
+        // 1. 주기 생성
+        DuesCycle cycle = DuesCycle.builder()
+                .teamId(team.getId())
+                .name(range.name())
+                .startDate(range.start())
+                .endDate(range.end())
+                .build();
+        duesCycleRepository.save(cycle);
+
+        // 2. 현재 Active 멤버들에 대해 UNPAID 상태 생성
+        List<TeamMember> members = teamMemberRepository.findAllByTeam(team);
+        List<DuesMemberStatus> statuses = new ArrayList<>();
+
+        for (TeamMember m : members) {
+            if (m.getStatus() == TeamMemberStatus.ACTIVE) {
+                statuses.add(DuesMemberStatus.builder()
+                        .cycle(cycle)
+                        .userId(m.getUser().getId())
+                        .amount(team.getDuesAmount())
+                        .build());
+            }
+        }
+        duesMemberStatusRepository.saveAll(statuses);
+
+        return cycle;
+    }
+
+    private DuesCycleDetailDto createDetailDto(DuesCycle cycle) {
+        List<DuesMemberStatus> statusList = duesMemberStatusRepository.findAllByCycle(cycle);
+
+        List<DuesMemberDto> paidMembers = new ArrayList<>();
+        List<DuesMemberDto> unpaidMembers = new ArrayList<>();
+        long totalCollected = 0;
+        long totalExpected = 0;
+
+        for (DuesMemberStatus status : statusList) {
+            String userName = teamMemberRepository.findByTeamIdAndUserId(cycle.getTeamId(), status.getUserId())
+                    .map(tm -> tm.getUser().getNickname())
+                    .orElse("(알수없음)");
+
+            DuesMemberDto dto = new DuesMemberDto(
+                    status.getUserId(),
+                    userName,
+                    status.getStatus(),
+                    status.getAmount(),
+                    status.getPaidAt(),
+                    null // memo
+            );
+
+            totalExpected += status.getAmount();
+
+            if (status.getStatus() == DuesStatus.PAID) {
+                paidMembers.add(dto);
+                totalCollected += status.getAmount();
+            } else {
+                unpaidMembers.add(dto);
+            }
+        }
+
+        return new DuesCycleDetailDto(
+                cycle.getId(),
+                cycle.getName(),
+                cycle.getStartDate(),
+                cycle.getEndDate(),
+                paidMembers,
+                unpaidMembers,
+                statusList.size(),
+                paidMembers.size(),
+                totalExpected,
+                totalCollected
+        );
+    }
+}

--- a/src/main/java/com/moau/moau/global/exception/error/DuesError.java
+++ b/src/main/java/com/moau/moau/global/exception/error/DuesError.java
@@ -1,0 +1,21 @@
+package com.moau.moau.global.exception.error;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DuesError implements BaseError {
+
+    CYCLE_NOT_FOUND(HttpStatus.NOT_FOUND, "DUES_CYCLE_NOT_FOUND", "회비 납부 주기를 찾을 수 없습니다."),
+    MEMBER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "DUES_MEMBER_STATUS_NOT_FOUND", "해당 멤버의 납부 정보를 찾을 수 없습니다."),
+    INVALID_CYCLE_DATE(HttpStatus.BAD_REQUEST, "INVALID_CYCLE_DATE", "유효하지 않은 회비 주기 날짜입니다."),
+    TEAM_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "TEAM_SETTING_NOT_FOUND", "팀의 회비 설정(주기/금액)이 되어있지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override public HttpStatus getHttpStatus() { return httpStatus; }
+    @Override public String getCode()          { return code; }
+    @Override public String getMessage()       { return message; }
+}

--- a/src/main/java/com/moau/moau/team/domain/DuesPeriod.java
+++ b/src/main/java/com/moau/moau/team/domain/DuesPeriod.java
@@ -1,0 +1,17 @@
+package com.moau.moau.team.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DuesPeriod {
+    NONE("없음", 0),
+    MONTHLY("매월", 1),
+    QUARTERLY("분기(3개월)", 3),
+    HALF_YEARLY("반기(6개월)", 6),
+    YEARLY("매년(12개월)", 12);
+
+    private final String description;
+    private final int months;
+}

--- a/src/main/java/com/moau/moau/team/domain/Team.java
+++ b/src/main/java/com/moau/moau/team/domain/Team.java
@@ -12,7 +12,7 @@ import com.moau.moau.user.domain.User;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "TEAMS") // [ 수정] "TEAMS" (대문자 복수형)
+@Table(name = "TEAMS")
 public class Team extends BaseSoftDelete {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,4 +27,18 @@ public class Team extends BaseSoftDelete {
 
     @Column(name = "invite_code", length = 8, unique = true)
     private String inviteCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dues_period", nullable = false)
+    @Builder.Default
+    private DuesPeriod duesPeriod = DuesPeriod.NONE;
+
+    @Column(name = "dues_amount", nullable = false)
+    @Builder.Default
+    private Long duesAmount = 0L;
+
+    public void updateDuesSetting(DuesPeriod period, Long amount) {
+        this.duesPeriod = period;
+        this.duesAmount = amount;
+    }
 }

--- a/src/main/java/com/moau/moau/team/domain/TeamFactory.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamFactory.java
@@ -4,9 +4,8 @@ import com.moau.moau.user.domain.User;
 
 public class TeamFactory {
 
-    // 같은 패키지라서 Team의 protected 생성자 사용 가능
     public static Team create(User owner, String name, String description, String inviteCode) {
-        Team team = new Team();   // 여기서는 에러 안 남
+        Team team = new Team();
         team.setOwner(owner);
         team.setName(name);
         team.setDescription(description);

--- a/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
@@ -44,7 +44,6 @@ public class TeamMemberFactory {
             field.setAccessible(true);
             field.set(target, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            // 통일된 방식: CommonError.getMessage()
             throw new IllegalStateException(CommonError.TEAM_MEMBER_FIELD_ERROR.getMessage());
         }
     }

--- a/src/main/java/com/moau/moau/team/domain/TeamMemberId.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMemberId.java
@@ -13,10 +13,10 @@ import java.io.Serializable;
 @EqualsAndHashCode
 public class TeamMemberId implements Serializable {
 
-    @Column(name = "TEAM_ID") // [ 수정] 대문자
+    @Column(name = "TEAM_ID")
     private Long teamId;
 
-    @Column(name = "USER_ID") // [ 수정] 대문자
+    @Column(name = "USER_ID")
     private Long userId;
 
     public TeamMemberId(Long teamId, Long userId) {

--- a/src/main/java/com/moau/moau/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/moau/moau/team/dto/request/TeamUpdateRequest.java
@@ -1,8 +1,24 @@
 package com.moau.moau.team.dto.request;
 
+import com.moau.moau.team.domain.DuesPeriod;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 public record TeamUpdateRequest(
-        @NotBlank String name,
-        String description
-) {}
+        @NotBlank(message = "팀 이름은 필수입니다.")
+        @Size(max = 20, message = "팀 이름은 20자 이내여야 합니다.")
+        String name,
+
+        @Size(max = 100, message = "팀 설명은 100자 이내여야 합니다.")
+        String description,
+
+        @NotNull(message = "회비 주기는 필수입니다. (없음=NONE)")
+        DuesPeriod duesPeriod,
+
+        @NotNull(message = "회비 금액은 필수입니다.")
+        @PositiveOrZero(message = "회비 금액은 0원 이상이어야 합니다.")
+        Long duesAmount
+) {
+}

--- a/src/main/java/com/moau/moau/team/dto/response/TeamDetailResponse.java
+++ b/src/main/java/com/moau/moau/team/dto/response/TeamDetailResponse.java
@@ -1,5 +1,6 @@
 package com.moau.moau.team.dto.response;
 
+import com.moau.moau.team.domain.DuesPeriod; // Enum import
 import com.moau.moau.team.domain.Team;
 
 import java.time.Instant;
@@ -10,7 +11,10 @@ public record TeamDetailResponse(
         String name,
         String description,
         String inviteCode,
-        Instant createdAt
+        Instant createdAt,
+
+        DuesPeriod duesPeriod,
+        Long duesAmount
 ) {
     public static TeamDetailResponse from(Team t) {
         return new TeamDetailResponse(
@@ -19,7 +23,10 @@ public record TeamDetailResponse(
                 t.getName(),
                 t.getDescription(),
                 t.getInviteCode(),
-                t.getCreatedAt()
+                t.getCreatedAt(),
+
+                t.getDuesPeriod(),
+                t.getDuesAmount()
         );
     }
 }

--- a/src/main/java/com/moau/moau/team/service/TeamCommandService.java
+++ b/src/main/java/com/moau/moau/team/service/TeamCommandService.java
@@ -49,6 +49,8 @@ public class TeamCommandService {
         team.setName(req.name());
         team.setDescription(req.description());
 
+        team.updateDuesSetting(req.duesPeriod(), req.duesAmount());
+
         return TeamDetailResponse.from(team);
     }
 


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #55 
---
### 📌 요약
- 회비 관리 도메인 구현 및 api 구현

### ✅ 작업 내용
-**1. 회비(Dues) 도메인 신설**
- **Entities:** `DuesCycle`(납부 주기), `DuesMemberStatus`(멤버별 납부 상태), `DuesStatus`(Enum)
- **Service (CQS):**
  - `DuesQueryService`: 회비 현황 조회 시, 데이터가 없으면 팀 설정에 맞춰 자동 생성(Lazy Loading)
  - `DuesCommandService`: 납부 상태 변경(`PAID` <-> `UNPAID`) 및 뱅킹 서비스 호출
- **Controller:** 관리자 전용 API (`@CheckTeamRole(ADMIN)`) 3종 구현

**2. 뱅킹(Banking) 도메인 확장**
- `BankingCommandService`에 수입 기록을 위한 `recordIncome()` 메서드 추가
- 기존 `recordExpense()`와 함께 회비 납부/취소 시 잔액이 실시간으로 반영되도록 연동

**3. 팀(Team) 도메인 수정**
- `Team` 엔티티에 회비 설정 필드(`duesPeriod`, `duesAmount`) 추가
- `DuesPeriod` Enum 정의 (매월, 분기, 반기, 매년, 없음)
- 팀 수정 API(`updateTeam`)에 회비 설정 변경 로직 반영

### 📚 참고 자료, 할 말
-
