### PR TITLE
[fix] hibernate 자료형 깨지는 문제 수정

### DIFF
--- a/src/main/java/com/moau/moau/team/domain/TeamMember.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMember.java
@@ -31,7 +31,7 @@ public class TeamMember {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     private TeamMemberRole role;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #
---
### 📌 요약
- main 서버에 hibernate가 role을 tinyint로 착각하는 문제 수정

### ✅ 작업 내용
- TeamMember에 role의 자료형 varchar(252)로 고정

### 📚 참고 자료, 할 말
-
