### PR TITLE
feat(Notice): 사진 업로드 및 S3 저장

### DIFF
--- a/src/main/java/com/moau/moau/notice/controller/NoticeController.java
+++ b/src/main/java/com/moau/moau/notice/controller/NoticeController.java
@@ -1,5 +1,7 @@
 package com.moau.moau.notice.controller;
 
+import com.moau.moau.accounting.receipt.dto.request.PresignedUrlRequestDto;
+import com.moau.moau.accounting.receipt.dto.response.PresignedUrlResponseDto;
 import com.moau.moau.global.payload.ResponseDto;
 import com.moau.moau.global.security.SecurityUtil;
 import com.moau.moau.global.security.CheckTeamRole;
@@ -15,8 +17,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,6 +33,16 @@ public class NoticeController implements NoticeControllerSwagger {
 
     @Override
     @CheckTeamRole(TeamMemberRole.ADMIN)
+    public ResponseEntity<ResponseDto<PresignedUrlResponseDto>> createPresignedUrl(
+            @PathVariable Long teamId,
+            @Valid @RequestBody PresignedUrlRequestDto requestDto
+    ) {
+        PresignedUrlResponseDto responseDto = noticeCommandService.createPresignedUrl(requestDto.filename());
+        return ResponseEntity.ok(ResponseDto.data(responseDto));
+    }
+
+    @Override
+    @CheckTeamRole(TeamMemberRole.ADMIN)
     public ResponseEntity<ResponseDto<Long>> createNotice(
             @PathVariable Long teamId,
             @Valid @RequestBody NoticeCreateRequestDto requestDto
@@ -46,7 +56,7 @@ public class NoticeController implements NoticeControllerSwagger {
     @CheckTeamRole(TeamMemberRole.MEMBER)
     public ResponseEntity<ResponseDto<Page<NoticeResponseDto>>> getNotices(
             @PathVariable Long teamId,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10) Pageable pageable
+            Pageable pageable
     ) {
         return ResponseEntity.ok(ResponseDto.data(noticeQueryService.getNotices(teamId, pageable)));
     }
@@ -68,7 +78,7 @@ public class NoticeController implements NoticeControllerSwagger {
             @PathVariable Long noticeId
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
-        noticeCommandService.deleteNotice(userId, noticeId);
+        noticeCommandService.deleteNotice(userId, teamId, noticeId);
         return ResponseEntity.ok(ResponseDto.message("공지사항이 삭제되었습니다."));
     }
 

--- a/src/main/java/com/moau/moau/notice/controller/NoticeControllerSwagger.java
+++ b/src/main/java/com/moau/moau/notice/controller/NoticeControllerSwagger.java
@@ -1,5 +1,7 @@
 package com.moau.moau.notice.controller;
 
+import com.moau.moau.accounting.receipt.dto.request.PresignedUrlRequestDto;
+import com.moau.moau.accounting.receipt.dto.response.PresignedUrlResponseDto;
 import com.moau.moau.global.exception.ErrorResponse;
 import com.moau.moau.global.payload.ResponseDto;
 import com.moau.moau.notice.dto.request.NoticeCreateRequestDto;
@@ -23,7 +25,16 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/teams/{teamId}/notices")
 public interface NoticeControllerSwagger {
 
-    @Operation(summary = "공지사항 작성", description = "(Auth: ADMIN) 공지사항을 작성합니다. (투표 포함 가능)")
+    // [신규 추가] 이미지 업로드 URL 발급
+    @Operation(summary = "공지 이미지 업로드 URL 발급", description = "(Auth: ADMIN) S3에 이미지를 업로드하기 위한 Pre-signed URL을 발급합니다.")
+    @ApiResponse(responseCode = "200", description = "발급 성공")
+    @PostMapping("/upload-url")
+    ResponseEntity<ResponseDto<PresignedUrlResponseDto>> createPresignedUrl(
+            @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId,
+            @Valid @RequestBody PresignedUrlRequestDto requestDto
+    );
+
+    @Operation(summary = "공지사항 작성", description = "(Auth: ADMIN) 공지사항을 작성합니다. (투표 및 이미지 키 리스트 포함 가능)")
     @ApiResponse(responseCode = "201", description = "작성 성공")
     @PostMapping
     ResponseEntity<ResponseDto<Long>> createNotice(
@@ -31,6 +42,7 @@ public interface NoticeControllerSwagger {
             @Valid @RequestBody NoticeCreateRequestDto requestDto
     );
 
+    // ... (나머지 API 동일)
     @Operation(summary = "공지사항 목록 조회", description = "(Auth: MEMBER) 공지사항 목록을 페이징하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping

--- a/src/main/java/com/moau/moau/notice/domain/NoticeImage.java
+++ b/src/main/java/com/moau/moau/notice/domain/NoticeImage.java
@@ -1,0 +1,32 @@
+package com.moau.moau.notice.domain;
+
+import com.moau.moau.global.domain.BaseId;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notice_images")
+public class NoticeImage extends BaseId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(name = "image_key", nullable = false)
+    private String imageKey; // S3 Key
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Builder
+    public NoticeImage(Notice notice, String imageKey, int sortOrder) {
+        this.notice = notice;
+        this.imageKey = imageKey;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/moau/moau/notice/dto/request/NoticeCreateRequestDto.java
+++ b/src/main/java/com/moau/moau/notice/dto/request/NoticeCreateRequestDto.java
@@ -16,6 +16,9 @@ public record NoticeCreateRequestDto(
 
         boolean isPinned, // 상단 고정 여부
 
+        @Size(max = 5, message = "이미지는 최대 5장까지 첨부할 수 있습니다.")
+        List<String> imageKeys,
+
         @Valid
         PollCreateDto poll
 ) {

--- a/src/main/java/com/moau/moau/notice/dto/response/NoticeDetailResponseDto.java
+++ b/src/main/java/com/moau/moau/notice/dto/response/NoticeDetailResponseDto.java
@@ -11,6 +11,7 @@ public record NoticeDetailResponseDto(
         boolean isPinned,
         boolean isMyNotice,
         Instant createdAt,
+        List<String> imageUrls,
 
         PollDto poll
 ) {

--- a/src/main/java/com/moau/moau/notice/repository/NoticeImageRepository.java
+++ b/src/main/java/com/moau/moau/notice/repository/NoticeImageRepository.java
@@ -1,0 +1,9 @@
+package com.moau.moau.notice.repository;
+
+import com.moau.moau.notice.domain.NoticeImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface NoticeImageRepository extends JpaRepository<NoticeImage, Long> {
+    List<NoticeImage> findAllByNoticeIdOrderBySortOrderAsc(Long noticeId);
+}

--- a/src/main/java/com/moau/moau/notice/service/NoticeCommandService.java
+++ b/src/main/java/com/moau/moau/notice/service/NoticeCommandService.java
@@ -1,10 +1,14 @@
 package com.moau.moau.notice.service;
 
+import com.moau.moau.accounting.receipt.port.StorageServicePort;
+import com.moau.moau.accounting.receipt.dto.response.PresignedUrlResponseDto;
 import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.notice.domain.Notice;
+import com.moau.moau.notice.domain.NoticeImage;
 import com.moau.moau.notice.dto.request.NoticeCreateRequestDto;
 import com.moau.moau.global.exception.error.NoticeError;
+import com.moau.moau.notice.repository.NoticeImageRepository;
 import com.moau.moau.notice.repository.NoticeRepository;
 import com.moau.moau.poll.domain.Poll;
 import com.moau.moau.poll.domain.PollOption;
@@ -15,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -23,17 +28,22 @@ import java.util.List;
 public class NoticeCommandService {
 
     private final NoticeRepository noticeRepository;
+    private final NoticeImageRepository noticeImageRepository;
     private final PollRepository pollRepository;
     private final PollOptionRepository pollOptionRepository;
     private final TeamRepository teamRepository;
 
-    // 공지사항 생성 (투표 포함 가능)
+    private final StorageServicePort storageServicePort;
+
+    public PresignedUrlResponseDto createPresignedUrl(String filename) {
+        return storageServicePort.createPresignedUrl(filename);
+    }
+
     public Long createNotice(Long userId, Long teamId, NoticeCreateRequestDto dto) {
         if (!teamRepository.existsById(teamId)) {
             throw new BusinessException(CommonError.TEAM_NOT_FOUND);
         }
 
-        // 1. Notice 생성
         boolean hasPoll = (dto.poll() != null);
         Notice notice = Notice.builder()
                 .teamId(teamId)
@@ -46,12 +56,34 @@ public class NoticeCommandService {
 
         Notice savedNotice = noticeRepository.save(notice);
 
-        // 2. Poll 생성 (있다면)
+        if (dto.imageKeys() != null && !dto.imageKeys().isEmpty()) {
+            List<NoticeImage> images = new ArrayList<>();
+            for (int i = 0; i < dto.imageKeys().size(); i++) {
+                images.add(NoticeImage.builder()
+                        .notice(savedNotice)
+                        .imageKey(dto.imageKeys().get(i))
+                        .sortOrder(i)
+                        .build());
+            }
+            noticeImageRepository.saveAll(images);
+        }
+
         if (hasPoll) {
             createPoll(savedNotice, dto.poll());
         }
 
         return savedNotice.getId();
+    }
+
+    public void deleteNotice(Long userId, Long teamId, Long noticeId) {
+        Notice notice = noticeRepository.findByIdAndTeamIdAndDeletedAtIsNull(noticeId, teamId)
+                .orElseThrow(() -> new BusinessException(NoticeError.NOTICE_NOT_FOUND));
+
+        if (!notice.getAuthorUserId().equals(userId)) {
+            throw new BusinessException(CommonError.ACCESS_DENIED);
+        }
+
+        notice.delete();
     }
 
     private void createPoll(Notice notice, NoticeCreateRequestDto.PollCreateDto pollDto) {
@@ -64,7 +96,6 @@ public class NoticeCommandService {
                 .build();
         Poll savedPoll = pollRepository.save(poll);
 
-        // 옵션 생성
         List<PollOption> options = pollDto.options().stream()
                 .map(text -> PollOption.builder()
                         .poll(savedPoll)
@@ -72,12 +103,5 @@ public class NoticeCommandService {
                         .build())
                 .toList();
         pollOptionRepository.saveAll(options);
-    }
-
-    // 공지 삭제
-    public void deleteNotice(Long userId, Long noticeId) {
-        Notice notice = noticeRepository.findByIdAndDeletedAtIsNull(noticeId)
-                .orElseThrow(() -> new BusinessException(NoticeError.NOTICE_NOT_FOUND));
-        notice.delete();
     }
 }

--- a/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
@@ -1,18 +1,21 @@
 package com.moau.moau.notice.service;
 
+import com.moau.moau.accounting.receipt.port.StorageServicePort;
 import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.notice.domain.Notice;
 import com.moau.moau.notice.dto.response.NoticeDetailResponseDto;
 import com.moau.moau.notice.dto.response.NoticeResponseDto;
 import com.moau.moau.notice.dto.response.PollDto;
 import com.moau.moau.global.exception.error.NoticeError;
+import com.moau.moau.notice.repository.NoticeImageRepository;
 import com.moau.moau.notice.repository.NoticeRepository;
 import com.moau.moau.poll.domain.Poll;
 import com.moau.moau.poll.domain.PollOption;
-import com.moau.moau.poll.domain.PollVote;
 import com.moau.moau.poll.repository.PollOptionRepository;
 import com.moau.moau.poll.repository.PollRepository;
 import com.moau.moau.poll.repository.PollVoteRepository;
+import com.moau.moau.team.repository.TeamRepository;
 import com.moau.moau.user.domain.User;
 import com.moau.moau.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,13 +34,19 @@ import java.util.stream.Collectors;
 public class NoticeQueryService {
 
     private final NoticeRepository noticeRepository;
+    private final NoticeImageRepository noticeImageRepository;
     private final PollRepository pollRepository;
     private final PollOptionRepository pollOptionRepository;
     private final PollVoteRepository pollVoteRepository;
+    private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+    private final StorageServicePort storageServicePort;
 
-    // 목록 조회
     public Page<NoticeResponseDto> getNotices(Long teamId, Pageable pageable) {
+        if (!teamRepository.existsById(teamId)) {
+            throw new BusinessException(CommonError.TEAM_NOT_FOUND);
+        }
+
         return noticeRepository.findAllByTeamIdAndDeletedAtIsNull(teamId, pageable)
                 .map(notice -> {
                     String authorName = getAuthorName(notice.getAuthorUserId());
@@ -57,7 +65,6 @@ public class NoticeQueryService {
                 });
     }
 
-    // 상세 조회 (투표 포함)
     public NoticeDetailResponseDto getNoticeDetail(Long currentUserId, Long teamId, Long noticeId) {
         Notice notice = noticeRepository.findByIdAndTeamIdAndDeletedAtIsNull(noticeId, teamId)
                 .orElseThrow(() -> new BusinessException(NoticeError.NOTICE_NOT_FOUND));
@@ -65,6 +72,13 @@ public class NoticeQueryService {
         String authorName = getAuthorName(notice.getAuthorUserId());
         boolean isMyNotice = notice.getAuthorUserId().equals(currentUserId);
 
+        // 2. 이미지 조회 -> S3 Pre-signed URL 변환
+        List<String> imageUrls = noticeImageRepository.findAllByNoticeIdOrderBySortOrderAsc(noticeId)
+                .stream()
+                .map(image -> storageServicePort.createPresignedGetUrl(image.getImageKey())) // Key -> URL
+                .toList();
+
+        // 3. 투표 정보 조회 (있을 경우)
         PollDto pollDto = null;
         if (notice.isHasPoll()) {
             pollDto = getPollDto(notice.getId(), currentUserId);
@@ -78,11 +92,11 @@ public class NoticeQueryService {
                 notice.isPinned(),
                 isMyNotice,
                 notice.getCreatedAt(),
+                imageUrls,
                 pollDto
         );
     }
 
-    // --- Helper: 투표 정보 조립 ---
     private PollDto getPollDto(Long noticeId, Long currentUserId) {
         Poll poll = pollRepository.findByNoticeId(noticeId).orElse(null);
         if (poll == null) return null;
@@ -90,7 +104,7 @@ public class NoticeQueryService {
         // 1. 옵션 목록 조회
         List<PollOption> options = pollOptionRepository.findAllByPollId(poll.getId());
 
-        // 2. 내가 투표한 내역 조회 (Set으로 변환하여 조회 성능 O(1))
+        // 2. 내가 투표한 옵션 ID 목록 조회
         Set<Long> myVotedOptionIds = pollVoteRepository.findAllByPollIdAndUserId(poll.getId(), currentUserId)
                 .stream()
                 .map(vote -> vote.getPollOption().getId())
@@ -98,10 +112,7 @@ public class NoticeQueryService {
 
         boolean isVoted = !myVotedOptionIds.isEmpty();
 
-        // 3. 총 투표자 수 계산 (단순 합계가 아니라 Unique User Count가 필요하면 쿼리 필요)
-        // 여기서는 단순 옵션별 득표수 합계를 보여주거나, PollVote count query를 날려야 함.
-        // MVP: 옵션별 voteCount 합계로 근사치 사용 (복수선택 시 중복 집계됨)
-        // 정확히 하려면: pollVoteRepository.countDistinctUserIdByPollId(poll.getId())
+        // 3. 총 투표 수 계산
         int totalVoteCount = options.stream().mapToInt(PollOption::getVoteCount).sum();
 
         // 4. DTO 변환
@@ -110,7 +121,7 @@ public class NoticeQueryService {
                         opt.getId(),
                         opt.getText(),
                         opt.getVoteCount(),
-                        myVotedOptionIds.contains(opt.getId()) // 내가 찍었는지
+                        myVotedOptionIds.contains(opt.getId()) // 내가 찍은 항목이면 true
                 ))
                 .toList();
 
@@ -128,6 +139,8 @@ public class NoticeQueryService {
     }
 
     private String getAuthorName(Long userId) {
-        return userRepository.findById(userId).map(User::getNickname).orElse("(알수없음)");
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .orElse("(알수없음)");
     }
 }

--- a/src/main/java/com/moau/moau/poll/repository/PollRepository.java
+++ b/src/main/java/com/moau/moau/poll/repository/PollRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PollRepository extends JpaRepository<Poll, Long> {
-
     Optional<Poll> findByNoticeId(Long noticeId);
 }

--- a/src/main/java/com/moau/moau/poll/service/PollCommandService.java
+++ b/src/main/java/com/moau/moau/poll/service/PollCommandService.java
@@ -26,14 +26,8 @@ public class PollCommandService {
     private final PollVoteRepository pollVoteRepository;
     private final TeamMemberRepository teamMemberRepository;
 
-    /**
-     * 투표하기 (생성 및 수정 통합)
-     * - 기존 투표 내역이 있으면 취소(차감) 후 재투표(증가)
-     * - 비관적 락 사용
-     */
     @Transactional
     public void vote(Long userId, Long teamId, Long pollId, VoteRequestDto dto) {
-        // 1. 기본 검증
         Poll poll = pollRepository.findById(pollId)
                 .orElseThrow(() -> new BusinessException(PollError.POLL_NOT_FOUND));
 
@@ -41,44 +35,35 @@ public class PollCommandService {
             throw new BusinessException(CommonError.ACCESS_DENIED);
         }
 
-        // 마감 체크
         if (poll.isClosed()) {
             throw new BusinessException(PollError.CLOSED_POLL);
         }
 
-        // 복수 선택 검증
         if (!poll.isAllowMultiple() && dto.pollOptionIds().size() > 1) {
             throw new BusinessException(PollError.MULTIPLE_SELECTION_NOT_ALLOWED);
         }
 
-        // 2. [취소 로직] 기존 투표 내역이 있다면 삭제하고 카운트 감소
         List<PollVote> existingVotes = pollVoteRepository.findAllByPollIdAndUserId(pollId, userId);
         if (!existingVotes.isEmpty()) {
             for (PollVote vote : existingVotes) {
-                // [LOCK] 감소시킬 옵션에 락 걸고 조회
                 PollOption option = pollOptionRepository.findByIdWithLock(vote.getPollOption().getId())
                         .orElseThrow(() -> new BusinessException(PollError.OPTION_NOT_FOUND));
 
-                option.decreaseVote(); // 카운트 -1
-                // (Dirty Checking으로 자동 저장됨)
+                option.decreaseVote();
             }
-            pollVoteRepository.deleteAll(existingVotes); // 내역 삭제
+            pollVoteRepository.deleteAllByPollIdAndUserId(pollId, userId);
         }
 
-        // 3. [투표 로직] 새 항목에 대해 투표 생성하고 카운트 증가
         for (Long optionId : dto.pollOptionIds()) {
-            // [LOCK] 증가시킬 옵션에 락 걸고 조회 (동시성 제어 핵심)
             PollOption option = pollOptionRepository.findByIdWithLock(optionId)
                     .orElseThrow(() -> new BusinessException(PollError.OPTION_NOT_FOUND));
 
-            // 옵션이 해당 투표 소속인지 검증 (안전장치)
             if (!option.getPoll().getId().equals(pollId)) {
                 throw new BusinessException(PollError.INVALID_OPTION);
             }
 
             option.increaseVote(); // 카운트 +1
 
-            // 내역 저장
             PollVote newVote = PollVote.builder()
                     .poll(poll)
                     .pollOption(option)


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #74 
---
### 📌 요약
- 공지사항에 최대 5장의 사진 업로드 기능 구현
- 상세 조회시 이미지 url 반환로직 구현

### ✅ 작업 내용
- 공지사항에 최대 5장의 사진 업로드 기능 구현
- 상세 조회시 이미지 url 반환로직 구현

### 📚 참고 자료, 할 말
-
