### PR TITLE
[feat] 권한 인가 우회 차단

### DIFF
--- a/src/main/java/com/moau/moau/global/security/TeamRoleInterceptor.java
+++ b/src/main/java/com/moau/moau/global/security/TeamRoleInterceptor.java
@@ -49,13 +49,18 @@ public class TeamRoleInterceptor implements HandlerInterceptor {
                 .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
         if (pathVariables == null || !pathVariables.containsKey("teamId")) {
-            throw new BusinessException(CommonError.BAD_REQUEST);
+            throw new BusinessException(CommonError.BAD_REQUEST, "teamId path variable is required");
         }
-        Long teamId = Long.parseLong(pathVariables.get("teamId"));
+        Long teamId;
+        try {
+            teamId = Long.parseLong(pathVariables.get("teamId"));
+        } catch (NumberFormatException e) {
+            throw new BusinessException(CommonError.BAD_REQUEST, "teamId must be a number");
+        }
 
         // 4. DB에서 '사용자의 실제 권한' 가져오기
-        TeamMember member = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED, "팀 멤버가 아닙니다."));
+        TeamMember member = teamMemberRepository.findActiveMember(teamId, userId)
+                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED, "팀 멤버가 아니거나 비활성 상태입니다."));
 
         TeamMemberRole actualRole = member.getRole();
 

--- a/src/main/java/com/moau/moau/request/controller/TeamJoinApproveController.java
+++ b/src/main/java/com/moau/moau/request/controller/TeamJoinApproveController.java
@@ -46,7 +46,7 @@ public class TeamJoinApproveController implements TeamJoinApproveControllerSwagg
             @PathVariable Long teamId,
             @PathVariable Long requestId
     ) {
-        approveService.approve(requestId);
+        approveService.approve(teamId, requestId);
         return ResponseEntity.ok("가입 신청이 승인되었습니다.");
     }
 
@@ -56,7 +56,7 @@ public class TeamJoinApproveController implements TeamJoinApproveControllerSwagg
             @PathVariable Long teamId,
             @PathVariable Long requestId
     ) {
-        approveService.reject(requestId);
+        approveService.reject(teamId, requestId);
         return ResponseEntity.ok("가입 신청이 거절되었습니다.");
     }
 }

--- a/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
+++ b/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
@@ -31,12 +31,18 @@ public class TeamJoinApproveService {
 
     /** 가입 승인 */
     @Transactional
-    public void approve(Long requestId) {
+    public void approve(Long teamId, Long requestId) {
 
         // 1) 승인자 조회
         Long approverUserId = SecurityUtil.getCurrentUserId();
         User approver = users.findById(approverUserId)
                 .orElseThrow(() -> new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage()));
+
+        var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
+                .orElseThrow(() -> new IllegalStateException(CommonError.ACCESS_DENIED.getMessage()));
+        if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
+            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+        }
 
         // 2) JoinRequest 조회
         JoinRequest req = joinRequests.findById(requestId)
@@ -44,6 +50,10 @@ public class TeamJoinApproveService {
 
         Team team = req.getTeam();
         User targetUser = req.getRequestUser();
+
+        if (!team.getId().equals(teamId) || team.isDeleted()) {
+            throw new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage());
+        }
 
         // 3) 이미 처리된 요청인지 검사
         if (!JoinRequestStatus.PENDING.equals(req.getStatus())) {
@@ -71,14 +81,24 @@ public class TeamJoinApproveService {
 
     /** 가입 거절 */
     @Transactional
-    public void reject(Long requestId) {
+    public void reject(Long teamId, Long requestId) {
 
         Long approverUserId = SecurityUtil.getCurrentUserId();
         User approver = users.findById(approverUserId)
                 .orElseThrow(() -> new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage()));
 
+        var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
+                .orElseThrow(() -> new IllegalStateException(CommonError.ACCESS_DENIED.getMessage()));
+        if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
+            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+        }
+
         JoinRequest req = joinRequests.findById(requestId)
                 .orElseThrow(() -> new IllegalStateException(CommonError.JOIN_REQUEST_NOT_FOUND.getMessage()));
+
+        if (!req.getTeam().getId().equals(teamId) || req.getTeam().isDeleted()) {
+            throw new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage());
+        }
 
         // 이미 처리된 요청인지
         if (!JoinRequestStatus.PENDING.equals(req.getStatus())) {

--- a/src/main/java/com/moau/moau/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/moau/moau/team/repository/TeamMemberRepository.java
@@ -7,6 +7,7 @@ import com.moau.moau.team.domain.TeamMemberId;
 import com.moau.moau.team.domain.TeamMemberStatus;
 import com.moau.moau.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,18 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemb
     Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
     boolean existsByTeamIdAndUserId(Long teamId, Long userId);
     boolean existsByTeam_IdAndUser_IdAndStatus(Long teamId, Long userId, TeamMemberStatus status);
+
+    /**
+     * 팀 소프트 삭제 여부까지 고려해 ACTIVE 멤버를 조회한다.
+     */
+    @Query("""
+            select tm
+            from TeamMember tm
+            join fetch tm.team t
+            where tm.id.teamId = :teamId
+              and tm.id.userId = :userId
+              and tm.status = 'ACTIVE'
+              and t.deletedAt is null
+            """)
+    Optional<TeamMember> findActiveMember(Long teamId, Long userId);
 }

--- a/src/main/java/com/moau/moau/team/service/TeamMemberService.java
+++ b/src/main/java/com/moau/moau/team/service/TeamMemberService.java
@@ -22,6 +22,18 @@ public class TeamMemberService {
     private final TeamMemberRepository teamMembers;
     private final UserRepository users;
 
+    private TeamMember requireMemberWithRole(Long teamId, Long userId, TeamMemberRole requiredRole) {
+        TeamMember member = teamMembers.findActiveMember(teamId, userId)
+                .orElseThrow(() ->
+                        new IllegalStateException(CommonError.ACCESS_DENIED.getMessage())
+                );
+
+        if (!member.getRole().isAtLeast(requiredRole)) {
+            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+        }
+        return member;
+    }
+
     /** 팀 멤버 목록 조회 */
     @Transactional(readOnly = true)
     public List<TeamMemberResponse> getTeamsMembers(Long teamId) {
@@ -74,6 +86,7 @@ public class TeamMemberService {
     public void leaveTeam(Long teamId) {
 
         Long currentUserId = SecurityUtil.getCurrentUserId();
+        requireMemberWithRole(teamId, currentUserId, TeamMemberRole.MEMBER);
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
@@ -104,6 +117,7 @@ public class TeamMemberService {
     public void changeMemberRole(Long teamId, Long targetUserId, TeamMemberRole newRole) {
 
         Long currentUserId = SecurityUtil.getCurrentUserId();
+        requireMemberWithRole(teamId, currentUserId, TeamMemberRole.OWNER);
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
@@ -138,6 +152,7 @@ public class TeamMemberService {
     public void kickMember(Long teamId, Long targetUserId) {
 
         Long currentUserId = SecurityUtil.getCurrentUserId();
+        requireMemberWithRole(teamId, currentUserId, TeamMemberRole.ADMIN);
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
@@ -168,6 +183,7 @@ public class TeamMemberService {
     public void transferOwner(Long teamId, Long newOwnerUserId) {
 
         Long currentUserId = SecurityUtil.getCurrentUserId();
+        requireMemberWithRole(teamId, currentUserId, TeamMemberRole.OWNER);
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #77
---
### 📌 요약
- 권한 인가 로직 우회 차단

### ✅ 작업 내용
- TeamRoleInterceptor spring bean 등록
- 요청의 teamId와 joinRequest 팀 일치 확인
- 팀 soft delete까지 반영하는 findActiveMember JPQL 추가.

### 📚 참고 자료, 할 말
- 테스트 확실하게 합시다
