### PR TITLE
[refactor] 예외처리 보강

### DIFF
--- a/src/main/java/com/moau/moau/accounting/receipt/apapter/OpenAiClient.java
+++ b/src/main/java/com/moau/moau/accounting/receipt/apapter/OpenAiClient.java
@@ -3,12 +3,15 @@ package com.moau.moau.accounting.receipt.apapter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moau.moau.accounting.receipt.dto.response.AiReceiptResult;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.CommonError;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -86,9 +89,10 @@ public class OpenAiClient {
 
             return new AiReceiptResult(merchantName, amount, date, paymentMethod);
 
+        } catch (WebClientResponseException e) {
+            throw new BusinessException(CommonError.EXTERNAL_API_ERROR, e.getResponseBodyAsString(), e);
         } catch (Exception e) {
-            log.error("[AI] Extraction failed: {}", e.getMessage());
-            return new AiReceiptResult("분석 실패", 0L, LocalDate.now(), null);
+            throw new BusinessException(CommonError.EXTERNAL_API_ERROR, e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/moau/moau/accounting/receipt/domain/ReceiptReview.java
+++ b/src/main/java/com/moau/moau/accounting/receipt/domain/ReceiptReview.java
@@ -1,6 +1,8 @@
 package com.moau.moau.accounting.receipt.domain;
 
 import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.CommonError;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -80,7 +82,7 @@ public class ReceiptReview extends BaseId {
     // (승인 메서드)
     public void approve(Long approverId) {
         if (this.status != ReviewStatus.PENDING_APPROVAL) {
-            throw new IllegalStateException("Not pending approval status");
+            throw new BusinessException(CommonError.BAD_REQUEST, "Not pending approval status");
         }
         this.status = ReviewStatus.APPROVED;
         this.approverId = approverId;
@@ -90,7 +92,7 @@ public class ReceiptReview extends BaseId {
     // (반려 메서드)
     public void reject(Long approverId, String reason) {
         if (this.status != ReviewStatus.PENDING_APPROVAL) {
-            throw new IllegalStateException("Not pending approval status");
+            throw new BusinessException(CommonError.BAD_REQUEST, "Not pending approval status");
         }
         this.status = ReviewStatus.REJECTED;
         this.approverId = approverId;

--- a/src/main/java/com/moau/moau/auth/service/KakaoOAuthClient.java
+++ b/src/main/java/com/moau/moau/auth/service/KakaoOAuthClient.java
@@ -2,10 +2,13 @@ package com.moau.moau.auth.service;
 
 import com.moau.moau.auth.dto.response.kakao.KakaoTokenResponse;
 import com.moau.moau.auth.dto.response.kakao.KakaoUserMeResponse;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.CommonError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * 카카오 API 호출 전용 클라이언트
@@ -14,29 +17,37 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class KakaoOAuthClient {
 
-    private final WebClient webClient = WebClient.create();
+    private final WebClient webClient;
     private final KakaoProperties kakaoProperties;
 
     public KakaoTokenResponse exchangeCodeForToken(String code, String codeVerifier, String redirectUri) {
-        return webClient.post()
-                .uri(kakaoProperties.tokenUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .bodyValue("grant_type=authorization_code"
-                        + "&client_id=" + kakaoProperties.restApiKey()
-                        + "&redirect_uri=" + redirectUri
-                        + "&code=" + code
-                        + "&code_verifier=" + codeVerifier)
-                .retrieve()
-                .bodyToMono(KakaoTokenResponse.class)
-                .block();
+        try {
+            return webClient.post()
+                    .uri(kakaoProperties.tokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue("grant_type=authorization_code"
+                            + "&client_id=" + kakaoProperties.restApiKey()
+                            + "&redirect_uri=" + redirectUri
+                            + "&code=" + code
+                            + "&code_verifier=" + codeVerifier)
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            throw new BusinessException(CommonError.EXTERNAL_API_ERROR, e.getResponseBodyAsString(), e);
+        }
     }
 
     public KakaoUserMeResponse getUserInfo(String accessToken) {
-        return webClient.get()
-                .uri(kakaoProperties.userMeUri())
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(KakaoUserMeResponse.class)
-                .block();
+        try {
+            return webClient.get()
+                    .uri(kakaoProperties.userMeUri())
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserMeResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            throw new BusinessException(CommonError.EXTERNAL_API_ERROR, e.getResponseBodyAsString(), e);
+        }
     }
 }

--- a/src/main/java/com/moau/moau/global/exception/ErrorResponse.java
+++ b/src/main/java/com/moau/moau/global/exception/ErrorResponse.java
@@ -11,10 +11,16 @@ public record ErrorResponse(
         int status,          // HTTP status code
         String code,         // 비즈니스 에러 코드
         String message,      // 사용자 메시지
-        String path      // 요청 URI
+        String path,         // 요청 URI
+        Object detail        // 추가 정보(필드 오류 등)
 ) {
     public static ErrorResponse of(HttpStatus status, String code, String message,
                                    String path) {
-        return new ErrorResponse(Instant.now(), status.value(), code, message, path);
+        return new ErrorResponse(Instant.now(), status.value(), code, message, path, null);
+    }
+
+    public static ErrorResponse of(HttpStatus status, String code, String message,
+                                   String path, Object detail) {
+        return new ErrorResponse(Instant.now(), status.value(), code, message, path, detail);
     }
 }

--- a/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
@@ -1,10 +1,22 @@
 package com.moau.moau.global.exception;
 
 import com.moau.moau.global.exception.error.BaseError;
+import com.moau.moau.global.exception.error.CommonError;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.WebClientResponseException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 @RestControllerAdvice
 public class ExceptionHandlerAdvice {
@@ -12,7 +24,82 @@ public class ExceptionHandlerAdvice {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex, HttpServletRequest request) {
         BaseError error = ex.getError();
-        ErrorResponse response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI());
+        ErrorResponse response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getDetail());
         return new ResponseEntity<>(response, error.getHttpStatus());
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        var details = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> new FieldErrorDetail(fieldError.getField(), fieldError.getDefaultMessage()))
+                .toList();
+        var error = CommonError.BAD_REQUEST;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), details);
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex, HttpServletRequest request) {
+        var details = ex.getConstraintViolations().stream()
+                .map(v -> new FieldErrorDetail(v.getPropertyPath().toString(), v.getMessage()))
+                .toList();
+        var error = CommonError.BAD_REQUEST;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), details);
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class, ServletRequestBindingException.class})
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception ex, HttpServletRequest request) {
+        var error = CommonError.BAD_REQUEST;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest request) {
+        var error = CommonError.AUTH_HEADER_INVALID;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        var error = CommonError.ACCESS_DENIED;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        var error = CommonError.BAD_REQUEST;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(WebClientResponseException.class)
+    public ResponseEntity<ErrorResponse> handleWebClientResponse(WebClientResponseException ex, HttpServletRequest request) {
+        var error = CommonError.EXTERNAL_API_ERROR;
+        var detail = new ExternalApiErrorDetail(ex.getStatusCode().value(), ex.getResponseBodyAsString());
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), detail);
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrity(DataIntegrityViolationException ex, HttpServletRequest request) {
+        var error = CommonError.DATA_INTEGRITY_VIOLATION;
+        var response = ErrorResponse.of(error.getHttpStatus(), error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMostSpecificCause().getMessage());
+        return ResponseEntity.status(error.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+        var error = CommonError.INTERNAL_SERVER_ERROR;
+        var response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    public record FieldErrorDetail(String field, String message) {}
+
+    public record ExternalApiErrorDetail(int status, String responseBody) {}
 }

--- a/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.WebClientResponseException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 

--- a/src/main/java/com/moau/moau/global/exception/error/CommonError.java
+++ b/src/main/java/com/moau/moau/global/exception/error/CommonError.java
@@ -18,6 +18,7 @@ public enum CommonError implements BaseError {
     KAKAO_ACCESS_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "KAKAO_ACCESS_TOKEN_REQUIRED", "카카오 accessToken 값이 필요합니다."),
     KAKAO_USERINFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "KAKAO_USERINFO_NOT_FOUND", "카카오 사용자 정보를 조회할 수 없습니다."),
     KAKAO_EMAIL_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "KAKAO_EMAIL_NOT_PROVIDED", "카카오 계정에서 이메일 정보를 제공하지 않았습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "EXTERNAL_API_ERROR", "외부 서비스 응답 오류입니다."),
 
     // REFRESH TOKEN
     REFRESH_TOKEN_INVALID_TYPE(HttpStatus.BAD_REQUEST, "REFRESH_TOKEN_INVALID_TYPE", "리프레시 토큰이 아닙니다."),
@@ -67,7 +68,9 @@ public enum CommonError implements BaseError {
 
     // ETC
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_NOT_FOUND", "그룹을 찾을 수 없습니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다.");
+    DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT, "DATA_INTEGRITY_VIOLATION", "데이터 무결성 위반이 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.moau.moau.jwt.config;
 
 import com.moau.moau.jwt.ports.JwtParserPort;
 import com.moau.moau.jwt.web.JwtAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -17,18 +18,25 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 public class SecurityConfig {
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtParserPort parser, HandlerExceptionResolver resolver) {
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            JwtParserPort parser,
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+    ) {
         return new JwtAuthenticationFilter(parser, resolver);
     }
 
     @Bean
-    public AuthenticationEntryPoint authenticationEntryPoint(HandlerExceptionResolver resolver) {
+    public AuthenticationEntryPoint authenticationEntryPoint(
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+    ) {
         return (request, response, authException) ->
                 resolver.resolveException(request, response, null, authException);
     }
 
     @Bean
-    public AccessDeniedHandler accessDeniedHandler(HandlerExceptionResolver resolver) {
+    public AccessDeniedHandler accessDeniedHandler(
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+    ) {
         return (request, response, accessDeniedException) ->
                 resolver.resolveException(request, response, null, accessDeniedException);
     }

--- a/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.security.web.authentication.AuthenticationEntryPoint;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 

--- a/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/moau/moau/jwt/config/SecurityConfig.java
@@ -8,20 +8,37 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtParserPort parser) {
-        return new JwtAuthenticationFilter(parser);
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtParserPort parser, HandlerExceptionResolver resolver) {
+        return new JwtAuthenticationFilter(parser, resolver);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint(HandlerExceptionResolver resolver) {
+        return (request, response, authException) ->
+                resolver.resolveException(request, response, null, authException);
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler(HandlerExceptionResolver resolver) {
+        return (request, response, accessDeniedException) ->
+                resolver.resolveException(request, response, null, accessDeniedException);
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
-            JwtAuthenticationFilter jwtFilter
+            JwtAuthenticationFilter jwtFilter,
+            AuthenticationEntryPoint authenticationEntryPoint,
+            AccessDeniedHandler accessDeniedHandler
     ) throws Exception {
 
         http
@@ -62,6 +79,12 @@ public class SecurityConfig {
 
                         // 그 외 모든 API는 인증 필요
                         .anyRequest().authenticated()
+                )
+
+                // 인증/인가 실패 시 전역 예외 처리로 위임
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
 
                 // JWT 필터 등록

--- a/src/main/java/com/moau/moau/jwt/infra/JwtParserAdapter.java
+++ b/src/main/java/com/moau/moau/jwt/infra/JwtParserAdapter.java
@@ -1,5 +1,6 @@
 package com.moau.moau.jwt.infra;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.jwt.ports.JwtParserPort;
 import com.moau.moau.jwt.config.JwtProps;
@@ -29,7 +30,7 @@ public class JwtParserAdapter implements JwtParserPort {
                     .parseSignedClaims(jwt)
                     .getPayload();
             if (c.getExpiration() == null || c.getExpiration().toInstant().isBefore(Instant.now())) {
-                throw new IllegalStateException(CommonError.TOKEN_EXPIRED.getMessage());
+                throw new BusinessException(CommonError.TOKEN_EXPIRED);
             }
 
             return new Parsed(
@@ -40,10 +41,10 @@ public class JwtParserAdapter implements JwtParserPort {
             );
         } catch (ExpiredJwtException e) {
             // 토큰 만료
-            throw new IllegalStateException(CommonError.TOKEN_EXPIRED.getMessage(), e);
+            throw new BusinessException(CommonError.TOKEN_EXPIRED, null, e);
         } catch (JwtException e) {
             // 서명 불일치, 파싱 실패 등 모든 토큰 유효성 문제
-            throw new IllegalStateException(CommonError.TOKEN_INVALID.getMessage(), e);
+            throw new BusinessException(CommonError.TOKEN_INVALID, null, e);
         }
     }
 }

--- a/src/main/java/com/moau/moau/jwt/web/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moau/moau/jwt/web/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 
@@ -17,6 +18,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtParserPort jwtParser;
+    private final HandlerExceptionResolver resolver;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -61,24 +63,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             );
             SecurityContextHolder.getContext().setAuthentication(auth);
 
-        } catch (IllegalStateException e) {
-            writeUnauthorized(res, e.getMessage());
-            return;
+            chain.doFilter(req, res);
+        } catch (Exception e) {
+            resolver.resolveException(req, res, null, e);
         }
-
-        chain.doFilter(req, res);
-    }
-
-    private void writeUnauthorized(HttpServletResponse res, String message) throws IOException {
-        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        res.setContentType("application/json;charset=UTF-8");
-
-        res.getWriter().write("""
-            {
-                "status": 401,
-                "code": "UNAUTHORIZED",
-                "message": "%s"
-            }
-            """.formatted(message));
     }
 }

--- a/src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
+++ b/src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
@@ -1,6 +1,7 @@
 // src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
 package com.moau.moau.request.domain;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.team.domain.Team;
 import com.moau.moau.user.domain.User;
@@ -47,8 +48,7 @@ public class JoinRequestFactory {
             field.set(target, value);
 
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            // ⭐ 네 프로젝트 규칙: new IllegalStateException + CommonError 메시지
-            throw new IllegalStateException(CommonError.JOIN_REQUEST_FIELD_ERROR.getMessage());
+            throw new BusinessException(CommonError.JOIN_REQUEST_FIELD_ERROR, null, e);
         }
     }
 }

--- a/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
+++ b/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
@@ -1,6 +1,7 @@
 // src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
 package com.moau.moau.request.service;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.security.SecurityUtil;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.request.domain.JoinRequest;
@@ -36,33 +37,33 @@ public class TeamJoinApproveService {
         // 1) 승인자 조회
         Long approverUserId = SecurityUtil.getCurrentUserId();
         User approver = users.findById(approverUserId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.USER_NOT_FOUND));
 
         var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.ACCESS_DENIED.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED));
         if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
-            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+            throw new BusinessException(CommonError.ACCESS_DENIED);
         }
 
         // 2) JoinRequest 조회
         JoinRequest req = joinRequests.findById(requestId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.JOIN_REQUEST_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.JOIN_REQUEST_NOT_FOUND));
 
         Team team = req.getTeam();
         User targetUser = req.getRequestUser();
 
         if (!team.getId().equals(teamId) || team.isDeleted()) {
-            throw new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage());
+            throw new BusinessException(CommonError.TEAM_NOT_FOUND);
         }
 
         // 3) 이미 처리된 요청인지 검사
         if (!JoinRequestStatus.PENDING.equals(req.getStatus())) {
-            throw new IllegalStateException(CommonError.JOIN_REQUEST_ALREADY_HANDLED.getMessage());
+            throw new BusinessException(CommonError.JOIN_REQUEST_ALREADY_HANDLED);
         }
 
         // 4) 이미 팀 멤버인지 검사
         if (teamMembers.existsByTeamAndUser(team, targetUser)) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_ALREADY_EXISTS.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_ALREADY_EXISTS);
         }
 
         // 5) 팀 멤버 등록
@@ -85,24 +86,24 @@ public class TeamJoinApproveService {
 
         Long approverUserId = SecurityUtil.getCurrentUserId();
         User approver = users.findById(approverUserId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.USER_NOT_FOUND));
 
         var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.ACCESS_DENIED.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED));
         if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
-            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+            throw new BusinessException(CommonError.ACCESS_DENIED);
         }
 
         JoinRequest req = joinRequests.findById(requestId)
-                .orElseThrow(() -> new IllegalStateException(CommonError.JOIN_REQUEST_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new BusinessException(CommonError.JOIN_REQUEST_NOT_FOUND));
 
         if (!req.getTeam().getId().equals(teamId) || req.getTeam().isDeleted()) {
-            throw new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage());
+            throw new BusinessException(CommonError.TEAM_NOT_FOUND);
         }
 
         // 이미 처리된 요청인지
         if (!JoinRequestStatus.PENDING.equals(req.getStatus())) {
-            throw new IllegalStateException(CommonError.JOIN_REQUEST_ALREADY_HANDLED.getMessage());
+            throw new BusinessException(CommonError.JOIN_REQUEST_ALREADY_HANDLED);
         }
 
         // 거절 처리

--- a/src/main/java/com/moau/moau/request/service/TeamJoinRequestService.java
+++ b/src/main/java/com/moau/moau/request/service/TeamJoinRequestService.java
@@ -1,5 +1,6 @@
 package com.moau.moau.request.service;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.request.domain.JoinRequest;
 import com.moau.moau.request.domain.JoinRequestFactory;
@@ -32,20 +33,20 @@ public class TeamJoinRequestService {
 
         Team team = teams.findByInviteCodeAndDeletedAtIsNull(inviteCode)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.INVITE_CODE_INVALID.getMessage())
+                        new BusinessException(CommonError.INVITE_CODE_INVALID)
                 );
 
         User user = users.findById(userId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.USER_NOT_FOUND)
                 );
 
         if (teamMembers.existsByTeamAndUser(team, user)) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_ALREADY_EXISTS.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_ALREADY_EXISTS);
         }
 
         if (joinRequests.existsByTeamAndRequestUserAndStatus(team, user, JoinRequestStatus.PENDING)) {
-            throw new IllegalStateException(CommonError.JOIN_REQUEST_ALREADY_EXISTS.getMessage());
+            throw new BusinessException(CommonError.JOIN_REQUEST_ALREADY_EXISTS);
         }
 
         JoinRequest req = JoinRequestFactory.createPending(team, user);

--- a/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
@@ -1,6 +1,7 @@
 // src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
 package com.moau.moau.team.domain;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.user.domain.User;
 
@@ -44,7 +45,7 @@ public class TeamMemberFactory {
             field.setAccessible(true);
             field.set(target, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_FIELD_ERROR.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_FIELD_ERROR, null, e);
         }
     }
 }

--- a/src/main/java/com/moau/moau/team/service/TeamMemberService.java
+++ b/src/main/java/com/moau/moau/team/service/TeamMemberService.java
@@ -1,5 +1,6 @@
 package com.moau.moau.team.service;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.global.security.SecurityUtil;
 import com.moau.moau.team.domain.*;
@@ -25,11 +26,11 @@ public class TeamMemberService {
     private TeamMember requireMemberWithRole(Long teamId, Long userId, TeamMemberRole requiredRole) {
         TeamMember member = teamMembers.findActiveMember(teamId, userId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.ACCESS_DENIED.getMessage())
+                        new BusinessException(CommonError.ACCESS_DENIED)
                 );
 
         if (!member.getRole().isAtLeast(requiredRole)) {
-            throw new IllegalStateException(CommonError.ACCESS_DENIED.getMessage());
+            throw new BusinessException(CommonError.ACCESS_DENIED);
         }
         return member;
     }
@@ -40,7 +41,7 @@ public class TeamMemberService {
 
         Team team = teams.findById(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         return teamMembers.findAllByTeam(team)
@@ -56,12 +57,12 @@ public class TeamMemberService {
 
         Team team = teams.findById(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         User owner = users.findById(ownerUserId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.USER_NOT_FOUND)
                 );
 
         TeamMemberId id = new TeamMemberId(teamId, ownerUserId);
@@ -90,22 +91,22 @@ public class TeamMemberService {
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         if (team.getOwner().getId().equals(currentUserId)) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_CANNOT_LEAVE.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_CANNOT_LEAVE);
         }
 
         TeamMemberId id = new TeamMemberId(teamId, currentUserId);
 
         TeamMember member = teamMembers.findById(id)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_MEMBER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_MEMBER_NOT_FOUND)
                 );
 
         if (member.getStatus() == TeamMemberStatus.LEFT) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_ALREADY_LEFT.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_ALREADY_LEFT);
         }
 
         member.setStatus(TeamMemberStatus.LEFT);
@@ -121,26 +122,26 @@ public class TeamMemberService {
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         if (!TeamMemberRole.ADMIN.equals(newRole) && !TeamMemberRole.MEMBER.equals(newRole)) {
-            throw new IllegalStateException(CommonError.TEAM_ROLE_INVALID.getMessage());
+            throw new BusinessException(CommonError.TEAM_ROLE_INVALID);
         }
 
         TeamMemberId targetId = new TeamMemberId(teamId, targetUserId);
 
         TeamMember target = teamMembers.findById(targetId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_MEMBER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_MEMBER_NOT_FOUND)
                 );
 
         if (target.getStatus() != TeamMemberStatus.ACTIVE) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_NOT_ACTIVE.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_NOT_ACTIVE);
         }
 
         if (TeamMemberRole.OWNER.equals(target.getRole())) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_ROLE_CANNOT_BE_CHANGED.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_ROLE_CANNOT_BE_CHANGED);
         }
 
         target.setRole(newRole);
@@ -156,22 +157,22 @@ public class TeamMemberService {
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         TeamMemberId targetId = new TeamMemberId(teamId, targetUserId);
 
         TeamMember target = teamMembers.findById(targetId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_MEMBER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_MEMBER_NOT_FOUND)
                 );
 
         if (target.getStatus() == TeamMemberStatus.LEFT) {
-            throw new IllegalStateException(CommonError.TEAM_MEMBER_ALREADY_LEFT.getMessage());
+            throw new BusinessException(CommonError.TEAM_MEMBER_ALREADY_LEFT);
         }
 
         if (TeamMemberRole.OWNER.equals(target.getRole())) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_CANNOT_BE_KICKED.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_CANNOT_BE_KICKED);
         }
 
         target.setStatus(TeamMemberStatus.LEFT);
@@ -187,33 +188,33 @@ public class TeamMemberService {
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         User currentOwner = team.getOwner();
 
         if (currentUserId.equals(newOwnerUserId)) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_TRANSFER_SELF.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_TRANSFER_SELF);
         }
 
         User newOwnerUser = users.findById(newOwnerUserId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.USER_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.USER_NOT_FOUND)
                 );
 
         TeamMemberId newOwnerMemberId = new TeamMemberId(teamId, newOwnerUserId);
 
         TeamMember newOwnerMember = teamMembers.findById(newOwnerMemberId)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.TEAM_OWNER_TRANSFER_TARGET_NOT_MEMBER.getMessage())
+                        new BusinessException(CommonError.TEAM_OWNER_TRANSFER_TARGET_NOT_MEMBER)
                 );
 
         if (newOwnerMember.getStatus() != TeamMemberStatus.ACTIVE) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_TRANSFER_TARGET_NOT_ACTIVE.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_TRANSFER_TARGET_NOT_ACTIVE);
         }
 
         if (TeamMemberRole.OWNER.equals(newOwnerMember.getRole())) {
-            throw new IllegalStateException(CommonError.TEAM_OWNER_ALREADY.getMessage());
+            throw new BusinessException(CommonError.TEAM_OWNER_ALREADY);
         }
 
         TeamMemberId currentOwnerMemberId = new TeamMemberId(teamId, currentUserId);

--- a/src/main/java/com/moau/moau/team/service/TeamQueryService.java
+++ b/src/main/java/com/moau/moau/team/service/TeamQueryService.java
@@ -1,5 +1,6 @@
 package com.moau.moau.team.service;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.team.domain.Team;
 import com.moau.moau.team.domain.TeamMember;
@@ -37,11 +38,11 @@ public class TeamQueryService {
 
         Team team = teams.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() ->
-                        new IllegalArgumentException(CommonError.TEAM_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.TEAM_NOT_FOUND)
                 );
 
         if (!team.getOwner().getId().equals(currentUserId)) {
-            throw new IllegalStateException(CommonError.TEAM_VIEW_FORBIDDEN.getMessage());
+            throw new BusinessException(CommonError.TEAM_VIEW_FORBIDDEN);
         }
 
         return TeamDetailResponse.from(team);

--- a/src/main/java/com/moau/moau/token/controller/TokenController.java
+++ b/src/main/java/com/moau/moau/token/controller/TokenController.java
@@ -2,7 +2,6 @@
 package com.moau.moau.token.controller;
 
 import com.moau.moau.auth.controller.AuthControllerSwagger;
-import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.token.service.TokenRefreshService;
 import com.moau.moau.token.dto.request.RefreshRequest;
 import com.moau.moau.token.dto.response.RefreshResponse;
@@ -25,20 +24,12 @@ public class TokenController {
     /** 리프레시 토큰 회전 */
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(@Valid @RequestBody RefreshRequest req) {
-        try {
-            var rotated = tokenRefreshService.rotate(req.getRefreshToken());
+        var rotated = tokenRefreshService.rotate(req.getRefreshToken());
 
-            return ResponseEntity.ok(new RefreshResponse(
-                    rotated.accessToken(),
-                    rotated.refreshToken(),
-                    rotated.refreshTokenExpiresAt()
-            ));
-        } catch (IllegalArgumentException e) {
-            // 예: rotate 내부에서 잘못된 토큰이면 IllegalArgumentException 던진다고 가정
-            var error = CommonError.REFRESH_TOKEN_INVALID;
-            return ResponseEntity
-                    .status(error.getHttpStatus())
-                    .body(error.getMessage());
-        }
+        return ResponseEntity.ok(new RefreshResponse(
+                rotated.accessToken(),
+                rotated.refreshToken(),
+                rotated.refreshTokenExpiresAt()
+        ));
     }
 }

--- a/src/main/java/com/moau/moau/token/service/TokenRefreshService.java
+++ b/src/main/java/com/moau/moau/token/service/TokenRefreshService.java
@@ -1,6 +1,7 @@
 // src/main/java/com/moau/moau/token/application/TokenRefreshService.java
 package com.moau.moau.token.service;
 
+import com.moau.moau.global.exception.BusinessException;
 import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.jwt.ports.JwtIssuerPort;
 import com.moau.moau.jwt.ports.JwtParserPort;
@@ -35,10 +36,10 @@ public class TokenRefreshService {
         var parsed = jwtParser.parse(refreshTokenRaw);
 
         if (!"RT".equals(parsed.typ())) {
-            throw new IllegalStateException(CommonError.REFRESH_TOKEN_INVALID_TYPE.getMessage());
+            throw new BusinessException(CommonError.REFRESH_TOKEN_INVALID_TYPE);
         }
         if (parsed.expiresAt().isBefore(Instant.now())) {
-            throw new IllegalStateException(CommonError.REFRESH_TOKEN_EXPIRED.getMessage());
+            throw new BusinessException(CommonError.REFRESH_TOKEN_EXPIRED);
         }
 
         String jti = parsed.jti();
@@ -46,13 +47,13 @@ public class TokenRefreshService {
 
         var rt = refreshTokens.findByJtiAndRevokedAtIsNull(jti)
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.REFRESH_TOKEN_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.REFRESH_TOKEN_NOT_FOUND)
                 );
 
         // 토큰 해시 일치 여부 확인
         byte[] incoming = sha256(refreshTokenRaw);
         if (!MessageDigest.isEqual(incoming, rt.getTokenHash())) {
-            throw new IllegalStateException(CommonError.REFRESH_TOKEN_MISMATCH.getMessage());
+            throw new BusinessException(CommonError.REFRESH_TOKEN_MISMATCH);
         }
 
         // 기존 RT 폐기
@@ -76,18 +77,18 @@ public class TokenRefreshService {
     public void revokeByRefreshToken(String refreshTokenRaw) {
         var parsed = jwtParser.parse(refreshTokenRaw);
         if (!"RT".equals(parsed.typ())) {
-            throw new IllegalStateException(CommonError.REFRESH_TOKEN_INVALID_TYPE.getMessage());
+            throw new BusinessException(CommonError.REFRESH_TOKEN_INVALID_TYPE);
         }
 
         var rt = refreshTokens.findByJtiAndRevokedAtIsNull(parsed.jti())
                 .orElseThrow(() ->
-                        new IllegalStateException(CommonError.REFRESH_TOKEN_NOT_FOUND.getMessage())
+                        new BusinessException(CommonError.REFRESH_TOKEN_NOT_FOUND)
                 );
 
         // 해시 검증
         byte[] incoming = sha256(refreshTokenRaw);
         if (!MessageDigest.isEqual(incoming, rt.getTokenHash())) {
-            throw new IllegalStateException(CommonError.REFRESH_TOKEN_MISMATCH.getMessage());
+            throw new BusinessException(CommonError.REFRESH_TOKEN_MISMATCH);
         }
 
         rt.revokeNow();
@@ -98,7 +99,7 @@ public class TokenRefreshService {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             return md.digest(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         } catch (Exception e) {
-            throw new IllegalStateException(CommonError.TOKEN_HASH_ERROR.getMessage());
+            throw new BusinessException(CommonError.TOKEN_HASH_ERROR, null, e);
         }
     }
 
@@ -108,4 +109,3 @@ public class TokenRefreshService {
             String refreshToken, java.time.Instant refreshTokenExpiresAt
     ) {}
 }
-


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #83 
---
### 📌 요약
-전역 예외 처리 인프라 확장: 다양한 스프링/DB/WebClient 예외를 ErrorResponse 포맷(+detail)으로 일원화.
- 보안/필터 경로 정리: JWT 필터와 시큐리티 EntryPoint/AccessDeniedHandler를 전역 핸들러로 위임.
- 도메인 예외 통일: 토큰 회전, 팀/가입, 영수증 리뷰 등에서 BusinessException으로 일관된 코드/상태 반환.
- 외부 API 예외 래핑: Kakao/OpenAI WebClient 오류를 비즈니스 예외로 변환.
- 테스트: RDS 연동 후 통합 테스트 성공

### ✅ 작업 내용
- 전역 핸들러/응답 확장: src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java에 WebClient/무결성/Validation/인증·인가 등 핸들러 추가, ErrorResponse에 detail 필드 추가
- ErrorResponse.java, 공통 에러 코드 보강
- 도메인 예외 통일: 토큰 회전 TokenRefreshService.java, 컨트롤러 try/catch 제거
- 팀/가입/멤버/팩토리/조회 서비스와 영수증 리뷰 등에서 IllegalStateException → BusinessException 변환
- 외부 API 예외 래핑: Kakao OAuth, OpenAI 클라이언트 WebClient 오류를 EXTERNAL_API_ERROR로 래핑


### 📚 참고 자료, 할 말
-
