### PR TITLE
merge: safe unmerged branches into develop

### DIFF
--- a/src/main/java/com/moau/moau/accounting/banking/service/BankingCommandService.java
+++ b/src/main/java/com/moau/moau/accounting/banking/service/BankingCommandService.java
@@ -83,60 +83,40 @@ public class BankingCommandService {
     @Transactional
     public void recordExpense(Long teamId, Long bankAccountId, Long amountCents, Long categoryId,
                               String description, LocalDate transactionDate, Long reviewId) {
-
-        Long currentUserId = SecurityUtil.getCurrentUserId();
-        requireMemberWithRole(teamId, currentUserId, TeamMemberRole.ADMIN);
-
-        BankAccount account = bankAccountRepository.findByIdAndTeamId(bankAccountId, teamId)
-                .orElseThrow(() -> new BusinessException(BankingError.ACCOUNT_NOT_FOUND));
-
-        teamRepository.findByIdAndDeletedAtIsNull(teamId)
-                .orElseThrow(() -> new BusinessException(CommonError.TEAM_NOT_FOUND));
-
-        categoryRepository.findByIdAndTeamId(categoryId, teamId)
-                .orElseThrow(() -> new BusinessException(CategoryError.NOT_FOUND));
-
-        BankTransaction expense = BankTransaction.builder()
-                .bankAccount(account)
-                .txnDate(transactionDate)
-                .amountCents(amountCents * -1)
-                .description(description)
-                .build();
-        bankTransactionRepository.save(expense);
-
-        // 4. 잔액 차감
-        updateBalance(account, amountCents * -1);
+        recordTransaction(teamId, bankAccountId, amountCents * -1, categoryId, description, transactionDate);
     }
 
     @Transactional
     public void recordIncome(Long teamId, Long bankAccountId, Long amountCents, Long categoryId,
                              String description, LocalDate transactionDate) {
+        recordTransaction(teamId, bankAccountId, amountCents, categoryId, description, transactionDate);
+    }
+
+    // (공통) 거래 기록 로직 추출
+    private void recordTransaction(Long teamId, Long bankAccountId, Long signedAmountCents,
+                                    Long categoryId, String description, LocalDate transactionDate) {
 
         Long currentUserId = SecurityUtil.getCurrentUserId();
         requireMemberWithRole(teamId, currentUserId, TeamMemberRole.ADMIN);
 
-        // 1. 계좌 소유권 검증
         BankAccount account = bankAccountRepository.findByIdAndTeamId(bankAccountId, teamId)
                 .orElseThrow(() -> new BusinessException(BankingError.ACCOUNT_NOT_FOUND));
 
         teamRepository.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() -> new BusinessException(CommonError.TEAM_NOT_FOUND));
 
-        // 2. 카테고리 검증
         categoryRepository.findByIdAndTeamId(categoryId, teamId)
                 .orElseThrow(() -> new BusinessException(CategoryError.NOT_FOUND));
 
-        // 3. 수입 내역 기록 (양수 저장)
-        BankTransaction income = BankTransaction.builder()
+        BankTransaction transaction = BankTransaction.builder()
                 .bankAccount(account)
                 .txnDate(transactionDate)
-                .amountCents(amountCents) // 양수
+                .amountCents(signedAmountCents)
                 .description(description)
                 .build();
-        bankTransactionRepository.save(income);
+        bankTransactionRepository.save(transaction);
 
-        // 4. 잔액 증가
-        updateBalance(account, amountCents);
+        updateBalance(account, signedAmountCents);
     }
 
     // (공통) 잔액 업데이트 로직 분리

--- a/src/main/java/com/moau/moau/accounting/dues/domain/DuesMemberStatus.java
+++ b/src/main/java/com/moau/moau/accounting/dues/domain/DuesMemberStatus.java
@@ -1,6 +1,8 @@
 package com.moau.moau.accounting.dues.domain;
 
 import com.moau.moau.global.domain.BaseId;
+import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.exception.error.DuesError;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.Instant;
@@ -10,6 +12,9 @@ import java.time.Instant;
 @Entity
 @Table(name = "dues_member_statuses")
 public class DuesMemberStatus extends BaseId {
+
+    @Version
+    private Long version;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cycle_id", nullable = false)
@@ -37,11 +42,17 @@ public class DuesMemberStatus extends BaseId {
     }
 
     public void markPaid() {
+        if (this.status == DuesStatus.PAID) {
+            throw new BusinessException(DuesError.ALREADY_PAID);
+        }
         this.status = DuesStatus.PAID;
         this.paidAt = Instant.now();
     }
 
     public void markUnpaid() {
+        if (this.status == DuesStatus.UNPAID) {
+            throw new BusinessException(DuesError.ALREADY_UNPAID);
+        }
         this.status = DuesStatus.UNPAID;
         this.paidAt = null;
     }

--- a/src/main/java/com/moau/moau/accounting/dues/domain/DuesStatusChangedEvent.java
+++ b/src/main/java/com/moau/moau/accounting/dues/domain/DuesStatusChangedEvent.java
@@ -1,0 +1,15 @@
+package com.moau.moau.accounting.dues.domain;
+
+import java.time.Instant;
+
+public record DuesStatusChangedEvent(
+        Long cycleId,
+        Long userId,
+        DuesStatus previousStatus,
+        DuesStatus newStatus,
+        Long amountCents,
+        Long changedBy,
+        Instant changedAt,
+        String cycleName
+) {
+}

--- a/src/main/java/com/moau/moau/accounting/dues/service/DuesCommandService.java
+++ b/src/main/java/com/moau/moau/accounting/dues/service/DuesCommandService.java
@@ -4,18 +4,22 @@ import com.moau.moau.accounting.banking.service.BankingCommandService;
 import com.moau.moau.accounting.dues.domain.DuesCycle;
 import com.moau.moau.accounting.dues.domain.DuesMemberStatus;
 import com.moau.moau.accounting.dues.domain.DuesStatus;
+import com.moau.moau.accounting.dues.domain.DuesStatusChangedEvent;
 import com.moau.moau.accounting.dues.dto.request.DuesStatusUpdateRequestDto;
 import com.moau.moau.accounting.dues.dto.response.DuesCycleDetailDto;
 import com.moau.moau.global.exception.error.DuesError;
 import com.moau.moau.accounting.dues.repository.DuesCycleRepository;
 import com.moau.moau.accounting.dues.repository.DuesMemberStatusRepository;
 import com.moau.moau.global.exception.BusinessException;
+import com.moau.moau.global.security.SecurityUtil;
 import com.moau.moau.user.domain.User;
 import com.moau.moau.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 @Service
@@ -28,6 +32,7 @@ public class DuesCommandService {
     private final BankingCommandService bankingCommandService;
     private final DuesQueryService duesQueryService;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public DuesCycleDetailDto updateMemberStatus(Long teamId, Long cycleId, Long targetUserId, DuesStatusUpdateRequestDto req) {
 
@@ -46,7 +51,11 @@ public class DuesCommandService {
 
         String userName = userRepository.findById(targetUserId).map(User::getNickname).orElse("멤버");
 
-        // 4. 상태 변경 및 뱅킹 연동
+        // 4. 이전 상태 저장 (감사 추적용)
+        DuesStatus previousStatus = memberStatus.getStatus();
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+
+        // 5. 상태 변경 및 뱅킹 연동
         if (req.status() == DuesStatus.PAID) {
             memberStatus.markPaid();
 
@@ -72,7 +81,19 @@ public class DuesCommandService {
             );
         }
 
-        // 5. 최신 현황 반환 (전체 리스트)
+        // 6. 이벤트 발행 (감사 추적)
+        eventPublisher.publishEvent(new DuesStatusChangedEvent(
+                cycleId,
+                targetUserId,
+                previousStatus,
+                req.status(),
+                memberStatus.getAmount(),
+                currentUserId,
+                Instant.now(),
+                cycle.getName()
+        ));
+
+        // 7. 최신 현황 반환 (전체 리스트)
         return duesQueryService.getCycleStatusById(teamId, cycleId);
     }
 }

--- a/src/main/java/com/moau/moau/accounting/dues/service/DuesEventListener.java
+++ b/src/main/java/com/moau/moau/accounting/dues/service/DuesEventListener.java
@@ -1,0 +1,31 @@
+package com.moau.moau.accounting.dues.service;
+
+import com.moau.moau.accounting.banking.service.BankingCommandService;
+import com.moau.moau.accounting.dues.domain.DuesStatus;
+import com.moau.moau.accounting.dues.domain.DuesStatusChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DuesEventListener {
+
+    private final BankingCommandService bankingCommandService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDuesStatusChanged(DuesStatusChangedEvent event) {
+        log.info("[Event] Dues status changed. cycleId: {}, userId: {}, {} -> {}",
+                event.cycleId(), event.userId(), event.previousStatus(), event.newStatus());
+
+        // 감사 추적 (Audit Trail) - 로그로 기록
+        log.info("[Audit] Dues status changed by user {}. Cycle: {}, Target User: {}, Amount: {}, {} -> {}",
+                event.changedBy(), event.cycleName(), event.userId(), event.amountCents(),
+                event.previousStatus(), event.newStatus());
+    }
+}

--- a/src/main/java/com/moau/moau/accounting/receipt/domain/ReceiptReview.java
+++ b/src/main/java/com/moau/moau/accounting/receipt/domain/ReceiptReview.java
@@ -2,7 +2,7 @@ package com.moau.moau.accounting.receipt.domain;
 
 import com.moau.moau.global.domain.BaseId;
 import com.moau.moau.global.exception.BusinessException;
-import com.moau.moau.global.exception.error.CommonError;
+import com.moau.moau.global.exception.error.ReceiptError;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -82,7 +82,7 @@ public class ReceiptReview extends BaseId {
     // (승인 메서드)
     public void approve(Long approverId) {
         if (this.status != ReviewStatus.PENDING_APPROVAL) {
-            throw new BusinessException(CommonError.BAD_REQUEST, "Not pending approval status");
+            throw new BusinessException(ReceiptError.ALREADY_REVIEW_COMPLETED);
         }
         this.status = ReviewStatus.APPROVED;
         this.approverId = approverId;
@@ -92,7 +92,7 @@ public class ReceiptReview extends BaseId {
     // (반려 메서드)
     public void reject(Long approverId, String reason) {
         if (this.status != ReviewStatus.PENDING_APPROVAL) {
-            throw new BusinessException(CommonError.BAD_REQUEST, "Not pending approval status");
+            throw new BusinessException(ReceiptError.ALREADY_REVIEW_COMPLETED);
         }
         this.status = ReviewStatus.REJECTED;
         this.approverId = approverId;

--- a/src/main/java/com/moau/moau/accounting/receipt/service/ReceiptReviewQueryService.java
+++ b/src/main/java/com/moau/moau/accounting/receipt/service/ReceiptReviewQueryService.java
@@ -12,6 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,11 +34,17 @@ public class ReceiptReviewQueryService {
             reviewPage = receiptReviewRepository.findByTeamIdAndStatus(teamId, status, pageable);
         }
 
+        // N+1 쿼리 방지: requester ID 수집 후 일괄 조회
+        Set<Long> requesterIds = reviewPage.stream()
+                .map(ReceiptReview::getRequesterId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> userNicknameMap = userRepository.findAllByIdIn(requesterIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+
         // Page<Entity> -> Page<DTO> 변환
         return reviewPage.map(review -> {
-            String requesterName = userRepository.findById(review.getRequesterId())
-                    .map(User::getNickname).orElse("N/A");
-
+            String requesterName = userNicknameMap.getOrDefault(review.getRequesterId(), "N/A");
             String imageUrl = review.getReceipt().getImageUrl();
 
             return new ReceiptReviewDto(

--- a/src/main/java/com/moau/moau/board/repository/CommentRepository.java
+++ b/src/main/java/com/moau/moau/board/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.moau.moau.board.repository;
 
 import com.moau.moau.board.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 2. 댓글 수정/삭제 시 확인용
     Optional<Comment> findByIdAndDeletedAtIsNull(Long id);
+
+    // 3. Lazy Loading 방지: Post와 함께 조회
+    @Query("SELECT c FROM Comment c JOIN FETCH c.post WHERE c.id = :commentId AND c.deletedAt IS NULL")
+    Optional<Comment> findByIdWithPost(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/moau/moau/board/repository/PostRepository.java
+++ b/src/main/java/com/moau/moau/board/repository/PostRepository.java
@@ -4,6 +4,9 @@ import com.moau.moau.board.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -17,4 +20,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 3. 수정/삭제 시 권한 및 소유권 확인용 (삭제 안 된 것만)
     Optional<Post> findByIdAndTeamIdAndDeletedAtIsNull(Long id, Long teamId);
+
+    // 4. Race Condition 방지: Atomic 업데이트 (Native Query)
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount + 1 WHERE p.id = :postId")
+    void incrementCommentCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId AND p.commentCount > 0")
+    void decrementCommentCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/moau/moau/board/service/CommentCommandService.java
+++ b/src/main/java/com/moau/moau/board/service/CommentCommandService.java
@@ -35,7 +35,8 @@ public class CommentCommandService {
 
         commentRepository.save(comment);
 
-        post.increaseCommentCount();
+        // Race Condition 방지: Native Query로 Atomic 업데이트
+        postRepository.incrementCommentCount(postId);
 
         return comment.getId();
     }
@@ -48,9 +49,11 @@ public class CommentCommandService {
             throw new BusinessException(BoardError.UNAUTHORIZED_ACCESS);
         }
 
+        Long postId = comment.getPost().getId();
         comment.delete();
 
-        comment.getPost().decreaseCommentCount();
+        // Race Condition 방지: Native Query로 Atomic 업데이트
+        postRepository.decrementCommentCount(postId);
     }
 
 }

--- a/src/main/java/com/moau/moau/board/service/CommentCommandService.java
+++ b/src/main/java/com/moau/moau/board/service/CommentCommandService.java
@@ -41,7 +41,8 @@ public class CommentCommandService {
     }
 
     public void deleteComment(Long userId, Long commentId) {
-        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+        // Fetch Join으로 Post와 함께 조회 (Lazy Loading 방지)
+        Comment comment = commentRepository.findByIdWithPost(commentId)
                 .orElseThrow(() -> new BusinessException(BoardError.COMMENT_NOT_FOUND));
 
         if (!comment.getAuthorUserId().equals(userId)) {

--- a/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/moau/moau/global/exception/ExceptionHandlerAdvice.java
@@ -2,10 +2,13 @@ package com.moau.moau.global.exception;
 
 import com.moau.moau.global.exception.error.BaseError;
 import com.moau.moau.global.exception.error.CommonError;
+import com.moau.moau.global.security.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +23,14 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 
+import java.util.Arrays;
+import java.util.UUID;
+
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ExceptionHandlerAdvice {
+
+    private final Environment environment;
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex, HttpServletRequest request) {
@@ -105,10 +114,45 @@ public class ExceptionHandlerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
-        log.error("Unhandled exception at {}: {}", request.getRequestURI(), ex.getMessage(), ex);
+        String errorId = UUID.randomUUID().toString();
+
+        // 강화된 로깅 (프로덕션 디버깅용)
+        log.error("Unhandled exception [errorId={}] at {}: {}",
+                errorId, request.getRequestURI(), ex.getMessage(), ex);
+        log.error("Request details [errorId={}]: userId={}, teamId={}, params={}",
+                errorId,
+                getCurrentUserIdSafe(),
+                request.getParameter("teamId"),
+                request.getParameterMap().keySet());
+
         var error = CommonError.INTERNAL_SERVER_ERROR;
-        var response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, error.getCode(), error.getMessage(), request.getRequestURI(), ex.getMessage());
+
+        // 프로덕션에서는 민감 정보 마스킹
+        String detail = isProductionProfile()
+                ? "Contact support with error ID: " + errorId
+                : ex.getMessage();
+
+        var response = ErrorResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                error.getCode(),
+                error.getMessage(),
+                request.getRequestURI(),
+                detail
+        );
+
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    private Long getCurrentUserIdSafe() {
+        try {
+            return SecurityUtil.getCurrentUserId();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean isProductionProfile() {
+        return Arrays.asList(environment.getActiveProfiles()).contains("prod");
     }
 
     public record FieldErrorDetail(String field, String message) {}

--- a/src/main/java/com/moau/moau/global/exception/error/DuesError.java
+++ b/src/main/java/com/moau/moau/global/exception/error/DuesError.java
@@ -9,7 +9,9 @@ public enum DuesError implements BaseError {
     CYCLE_NOT_FOUND(HttpStatus.NOT_FOUND, "DUES_CYCLE_NOT_FOUND", "회비 납부 주기를 찾을 수 없습니다."),
     MEMBER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "DUES_MEMBER_STATUS_NOT_FOUND", "해당 멤버의 납부 정보를 찾을 수 없습니다."),
     INVALID_CYCLE_DATE(HttpStatus.BAD_REQUEST, "INVALID_CYCLE_DATE", "유효하지 않은 회비 주기 날짜입니다."),
-    TEAM_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "TEAM_SETTING_NOT_FOUND", "팀의 회비 설정(주기/금액)이 되어있지 않습니다.");
+    TEAM_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "TEAM_SETTING_NOT_FOUND", "팀의 회비 설정(주기/금액)이 되어있지 않습니다."),
+    ALREADY_PAID(HttpStatus.CONFLICT, "ALREADY_PAID", "이미 납부된 회비입니다."),
+    ALREADY_UNPAID(HttpStatus.CONFLICT, "ALREADY_UNPAID", "이미 미납 상태입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
@@ -25,7 +25,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -47,9 +49,18 @@ public class NoticeQueryService {
             throw new BusinessException(CommonError.TEAM_NOT_FOUND);
         }
 
-        return noticeRepository.findAllByTeamIdAndDeletedAtIsNull(teamId, pageable)
-                .map(notice -> {
-                    String authorName = getAuthorName(notice.getAuthorUserId());
+        Page<Notice> notices = noticeRepository.findAllByTeamIdAndDeletedAtIsNull(teamId, pageable);
+
+        // N+1 쿼리 방지: 작성자 ID 수집 후 일괄 조회
+        Set<Long> authorIds = notices.stream()
+                .map(Notice::getAuthorUserId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> userNicknameMap = userRepository.findAllByIdIn(authorIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+
+        return notices.map(notice -> {
+                    String authorName = userNicknameMap.getOrDefault(notice.getAuthorUserId(), "(알수없음)");
                     String preview = notice.getContent().length() > 50 ?
                             notice.getContent().substring(0, 50) + "..." : notice.getContent();
 

--- a/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/moau/moau/notice/service/NoticeQueryService.java
@@ -98,11 +98,12 @@ public class NoticeQueryService {
     }
 
     private PollDto getPollDto(Long noticeId, Long currentUserId) {
-        Poll poll = pollRepository.findByNoticeId(noticeId).orElse(null);
+        // N+1 쿼리 방지: Poll과 PollOption을 함께 조회
+        Poll poll = pollRepository.findByNoticeIdWithOptions(noticeId).orElse(null);
         if (poll == null) return null;
 
-        // 1. 옵션 목록 조회
-        List<PollOption> options = pollOptionRepository.findAllByPollId(poll.getId());
+        // 1. 옵션 목록은 이미 Fetch Join으로 로드됨
+        List<PollOption> options = poll.getOptions();
 
         // 2. 내가 투표한 옵션 ID 목록 조회
         Set<Long> myVotedOptionIds = pollVoteRepository.findAllByPollIdAndUserId(poll.getId(), currentUserId)

--- a/src/main/java/com/moau/moau/poll/domain/Poll.java
+++ b/src/main/java/com/moau/moau/poll/domain/Poll.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,6 +32,9 @@ public class Poll extends BaseId {
 
     @Column(name = "deadline")
     private LocalDate deadline;
+
+    @OneToMany(mappedBy = "poll", fetch = FetchType.LAZY)
+    private List<PollOption> options = new ArrayList<>();
 
     @Builder
     public Poll(Notice notice, String title, boolean allowMultiple, boolean isAnonymous, LocalDate deadline) {

--- a/src/main/java/com/moau/moau/poll/repository/PollOptionRepository.java
+++ b/src/main/java/com/moau/moau/poll/repository/PollOptionRepository.java
@@ -4,6 +4,7 @@ import com.moau.moau.poll.domain.PollOption;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,13 @@ public interface PollOptionRepository extends JpaRepository<PollOption, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT po FROM PollOption po WHERE po.id = :id")
     Optional<PollOption> findByIdWithLock(@Param("id") Long id);
+
+    // 3. Race Condition 방지: Atomic 업데이트 (Native Query)
+    @Modifying
+    @Query("UPDATE PollOption po SET po.voteCount = po.voteCount + 1 WHERE po.id = :optionId")
+    void incrementVoteCount(@Param("optionId") Long optionId);
+
+    @Modifying
+    @Query("UPDATE PollOption po SET po.voteCount = po.voteCount - 1 WHERE po.id = :optionId AND po.voteCount > 0")
+    void decrementVoteCount(@Param("optionId") Long optionId);
 }

--- a/src/main/java/com/moau/moau/poll/repository/PollRepository.java
+++ b/src/main/java/com/moau/moau/poll/repository/PollRepository.java
@@ -2,9 +2,17 @@ package com.moau.moau.poll.repository;
 
 import com.moau.moau.poll.domain.Poll;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PollRepository extends JpaRepository<Poll, Long> {
     Optional<Poll> findByNoticeId(Long noticeId);
+
+    /**
+     * N+1 쿼리 방지: PollOption들과 함께 조회
+     */
+    @Query("SELECT p FROM Poll p LEFT JOIN FETCH p.options WHERE p.notice.id = :noticeId")
+    Optional<Poll> findByNoticeIdWithOptions(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/moau/moau/poll/service/PollCommandService.java
+++ b/src/main/java/com/moau/moau/poll/service/PollCommandService.java
@@ -43,26 +43,25 @@ public class PollCommandService {
             throw new BusinessException(PollError.MULTIPLE_SELECTION_NOT_ALLOWED);
         }
 
+        // 기존 투표 취소 (Native Query로 Atomic 업데이트)
         List<PollVote> existingVotes = pollVoteRepository.findAllByPollIdAndUserId(pollId, userId);
         if (!existingVotes.isEmpty()) {
             for (PollVote vote : existingVotes) {
-                PollOption option = pollOptionRepository.findByIdWithLock(vote.getPollOption().getId())
-                        .orElseThrow(() -> new BusinessException(PollError.OPTION_NOT_FOUND));
-
-                option.decreaseVote();
+                pollOptionRepository.decrementVoteCount(vote.getPollOption().getId());
             }
             pollVoteRepository.deleteAllByPollIdAndUserId(pollId, userId);
         }
 
+        // 새 투표 등록 (Native Query로 Atomic 업데이트)
         for (Long optionId : dto.pollOptionIds()) {
-            PollOption option = pollOptionRepository.findByIdWithLock(optionId)
+            PollOption option = pollOptionRepository.findById(optionId)
                     .orElseThrow(() -> new BusinessException(PollError.OPTION_NOT_FOUND));
 
             if (!option.getPoll().getId().equals(pollId)) {
                 throw new BusinessException(PollError.INVALID_OPTION);
             }
 
-            option.increaseVote(); // 카운트 +1
+            pollOptionRepository.incrementVoteCount(optionId);
 
             PollVote newVote = PollVote.builder()
                     .poll(poll)

--- a/src/main/java/com/moau/moau/request/domain/JoinRequest.java
+++ b/src/main/java/com/moau/moau/request/domain/JoinRequest.java
@@ -6,13 +6,17 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import com.moau.moau.user.domain.User;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "JOIN_REQUESTS") // [✅ 수정] 대문자 복수형
 public class JoinRequest extends BaseId {
@@ -37,5 +41,24 @@ public class JoinRequest extends BaseId {
     // ERD의 requested_at을 createdAt으로 사용하고 decided_at만 추가합니다.
     @Column(name = "decided_at")
     private Instant decidedAt;
+
+    // 상태 변경 메서드를 도메인 객체로 이동 (Rich Domain Model)
+    public void approve(User decider) {
+        this.status = JoinRequestStatus.APPROVED;
+        this.decidedBy = decider;
+        this.decidedAt = Instant.now();
+    }
+
+    public void reject(User decider) {
+        this.status = JoinRequestStatus.REJECTED;
+        this.decidedBy = decider;
+        this.decidedAt = Instant.now();
+    }
+
+    public void cancel(User requester) {
+        this.status = JoinRequestStatus.CANCELED;
+        this.decidedBy = requester;
+        this.decidedAt = Instant.now();
+    }
 
 }

--- a/src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
+++ b/src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
@@ -1,54 +1,18 @@
 // src/main/java/com/moau/moau/request/domain/JoinRequestFactory.java
 package com.moau.moau.request.domain;
 
-import com.moau.moau.global.exception.BusinessException;
-import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.team.domain.Team;
 import com.moau.moau.user.domain.User;
-
-import java.lang.reflect.Field;
-import java.time.Instant;
 
 public class JoinRequestFactory {
 
     public static JoinRequest createPending(Team team, User requestUser) {
-        JoinRequest req = new JoinRequest();
-
-        setField(req, "team", team);
-        setField(req, "requestUser", requestUser);
-        setField(req, "status", JoinRequestStatus.PENDING);
-        setField(req, "decidedBy", null);
-        setField(req, "decidedAt", null);
-
-        return req;
-    }
-
-    public static void approve(JoinRequest req, User decider, Instant now) {
-        setField(req, "status", JoinRequestStatus.APPROVED);
-        setField(req, "decidedBy", decider);
-        setField(req, "decidedAt", now);
-    }
-
-    public static void reject(JoinRequest req, User decider, Instant now) {
-        setField(req, "status", JoinRequestStatus.REJECTED);
-        setField(req, "decidedBy", decider);
-        setField(req, "decidedAt", now);
-    }
-
-    public static void cancel(JoinRequest req, User requester, Instant now) {
-        setField(req, "status", JoinRequestStatus.CANCELED);
-        setField(req, "decidedBy", requester);
-        setField(req, "decidedAt", now);
-    }
-
-    private static void setField(Object target, String fieldName, Object value) {
-        try {
-            Field field = target.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(target, value);
-
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new BusinessException(CommonError.JOIN_REQUEST_FIELD_ERROR, null, e);
-        }
+        return JoinRequest.builder()
+                .team(team)
+                .requestUser(requestUser)
+                .status(JoinRequestStatus.PENDING)
+                .decidedBy(null)
+                .decidedAt(null)
+                .build();
     }
 }

--- a/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
+++ b/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
@@ -20,8 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-
 @Service
 @RequiredArgsConstructor
 public class TeamJoinApproveService {
@@ -77,7 +75,7 @@ public class TeamJoinApproveService {
         teamMembers.save(member);
 
         // 6) JoinRequest 승인 처리
-        JoinRequestFactory.approve(req, approver, Instant.now());
+        req.approve(approver);
     }
 
     /** 가입 거절 */
@@ -107,6 +105,6 @@ public class TeamJoinApproveService {
         }
 
         // 거절 처리
-        JoinRequestFactory.reject(req, approver, Instant.now());
+        req.reject(approver);
     }
 }

--- a/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
+++ b/src/main/java/com/moau/moau/request/service/TeamJoinApproveService.java
@@ -34,16 +34,8 @@ public class TeamJoinApproveService {
     @Transactional
     public void approve(Long teamId, Long requestId) {
 
-        // 1) 승인자 조회
-        Long approverUserId = SecurityUtil.getCurrentUserId();
-        User approver = users.findById(approverUserId)
-                .orElseThrow(() -> new BusinessException(CommonError.USER_NOT_FOUND));
-
-        var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
-                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED));
-        if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
-            throw new BusinessException(CommonError.ACCESS_DENIED);
-        }
+        // 1) 승인자 권한 검증
+        User approver = requireAdminPermission(teamId);
 
         // 2) JoinRequest 조회
         JoinRequest req = joinRequests.findById(requestId)
@@ -72,7 +64,7 @@ public class TeamJoinApproveService {
                 targetUser,
                 TeamMemberRole.MEMBER,
                 TeamMemberStatus.ACTIVE,
-                approverUserId
+                approver.getId()
         );
         teamMembers.save(member);
 
@@ -84,15 +76,8 @@ public class TeamJoinApproveService {
     @Transactional
     public void reject(Long teamId, Long requestId) {
 
-        Long approverUserId = SecurityUtil.getCurrentUserId();
-        User approver = users.findById(approverUserId)
-                .orElseThrow(() -> new BusinessException(CommonError.USER_NOT_FOUND));
-
-        var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
-                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED));
-        if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
-            throw new BusinessException(CommonError.ACCESS_DENIED);
-        }
+        // 1) 승인자 권한 검증
+        User approver = requireAdminPermission(teamId);
 
         JoinRequest req = joinRequests.findById(requestId)
                 .orElseThrow(() -> new BusinessException(CommonError.JOIN_REQUEST_NOT_FOUND));
@@ -108,5 +93,26 @@ public class TeamJoinApproveService {
 
         // 거절 처리
         JoinRequestFactory.reject(req, approver, Instant.now());
+    }
+
+    /**
+     * Admin 권한을 가진 사용자인지 검증하고 User 객체를 반환합니다.
+     *
+     * @param teamId 팀 ID
+     * @return 검증된 User 객체
+     * @throws BusinessException 사용자가 없거나 권한이 없는 경우
+     */
+    private User requireAdminPermission(Long teamId) {
+        Long approverUserId = SecurityUtil.getCurrentUserId();
+        User approver = users.findById(approverUserId)
+                .orElseThrow(() -> new BusinessException(CommonError.USER_NOT_FOUND));
+
+        var approverMember = teamMembers.findActiveMember(teamId, approverUserId)
+                .orElseThrow(() -> new BusinessException(CommonError.ACCESS_DENIED));
+        if (!approverMember.getRole().isAtLeast(TeamMemberRole.ADMIN)) {
+            throw new BusinessException(CommonError.ACCESS_DENIED);
+        }
+
+        return approver;
     }
 }

--- a/src/main/java/com/moau/moau/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/moau/moau/schedule/repository/ScheduleRepository.java
@@ -8,9 +8,16 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    /**
+     * Lazy Loading 방지: Team과 함께 조회
+     */
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.team WHERE s.id = :scheduleId")
+    Optional<Schedule> findByIdWithTeam(@Param("scheduleId") Long scheduleId);
 
     /**
      * [기간 일정 지원] 특정 팀의 일정 중, 조회 기간(startAt ~ endAt)과 겹치는(Overlap) 모든 일정을 조회합니다.

--- a/src/main/java/com/moau/moau/schedule/service/ScheduleService.java
+++ b/src/main/java/com/moau/moau/schedule/service/ScheduleService.java
@@ -57,7 +57,8 @@ public class ScheduleService {
 
     // 2. 일정 상세 조회
     public ScheduleDetailResponse getScheduleDetail(Long scheduleId) {
-        Schedule schedule = scheduleRepository.findById(scheduleId)
+        // Fetch Join으로 Team과 함께 조회 (Lazy Loading 방지)
+        Schedule schedule = scheduleRepository.findByIdWithTeam(scheduleId)
                 .orElseThrow(() -> new BusinessException(ScheduleError.SCHEDULE_NOT_FOUND));
 
         validateActiveMember(schedule.getTeam().getId());
@@ -133,7 +134,8 @@ public class ScheduleService {
     public List<ScheduleResponse> getMySchedules(int year, int month) {
         Long currentUserId = SecurityUtil.getCurrentUserId();
 
-        List<TeamMember> myTeams = teamMemberRepository.findByUserId(currentUserId);
+        // N+1 쿼리 방지: Team과 함께 조회
+        List<TeamMember> myTeams = teamMemberRepository.findByUserIdWithTeam(currentUserId);
         List<Long> myTeamIds = myTeams.stream()
                 .map(teamMember -> teamMember.getTeam().getId())
                 .collect(Collectors.toList());
@@ -197,31 +199,31 @@ public class ScheduleService {
 
     // [내부 메서드 5] 시간 정규화 (생성용)
     private void normalizeScheduleTime(ScheduleCreateRequest request) {
-        ZoneId KST = ZoneId.of("Asia/Seoul");
-        LocalDate startDate = request.getStartsAt().atZone(KST).toLocalDate();
-        LocalDate endDate = request.getEndsAt().atZone(KST).toLocalDate();
-
-        if (!startDate.equals(endDate)) {
-            request.setAllDay(true);
-        }
-        if (request.isAllDay()) {
-            request.setStartsAt(startDate.atStartOfDay(KST).toInstant());
-            request.setEndsAt(endDate.atTime(LocalTime.MAX).atZone(KST).toInstant());
-        }
+        normalizeTime(request.getStartsAt(), request.getEndsAt(), request.isAllDay(),
+                      request::setAllDay, request::setStartsAt, request::setEndsAt);
     }
 
     // [내부 메서드 6] 시간 정규화 (수정용)
     private void normalizeScheduleTime(ScheduleUpdateRequest request) {
+        normalizeTime(request.getStartsAt(), request.getEndsAt(), request.isAllDay(),
+                      request::setAllDay, request::setStartsAt, request::setEndsAt);
+    }
+
+    // [내부 메서드 7] 시간 정규화 공통 로직 (중복 제거)
+    private void normalizeTime(Instant startsAt, Instant endsAt, boolean isAllDay,
+                              java.util.function.Consumer<Boolean> setAllDay,
+                              java.util.function.Consumer<Instant> setStartsAt,
+                              java.util.function.Consumer<Instant> setEndsAt) {
         ZoneId KST = ZoneId.of("Asia/Seoul");
-        LocalDate startDate = request.getStartsAt().atZone(KST).toLocalDate();
-        LocalDate endDate = request.getEndsAt().atZone(KST).toLocalDate();
+        LocalDate startDate = startsAt.atZone(KST).toLocalDate();
+        LocalDate endDate = endsAt.atZone(KST).toLocalDate();
 
         if (!startDate.equals(endDate)) {
-            request.setAllDay(true);
+            setAllDay.accept(true);
         }
-        if (request.isAllDay()) {
-            request.setStartsAt(startDate.atStartOfDay(KST).toInstant());
-            request.setEndsAt(endDate.atTime(LocalTime.MAX).atZone(KST).toInstant());
+        if (isAllDay || !startDate.equals(endDate)) {
+            setStartsAt.accept(startDate.atStartOfDay(KST).toInstant());
+            setEndsAt.accept(endDate.atTime(LocalTime.MAX).atZone(KST).toInstant());
         }
     }
 }

--- a/src/main/java/com/moau/moau/team/domain/TeamMember.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMember.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import com.moau.moau.user.domain.User;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +14,9 @@ import java.time.Instant;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "TEAM_MEMBERS")
 public class TeamMember {

--- a/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
+++ b/src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
@@ -1,11 +1,8 @@
 // src/main/java/com/moau/moau/team/domain/TeamMemberFactory.java
 package com.moau.moau.team.domain;
 
-import com.moau.moau.global.exception.BusinessException;
-import com.moau.moau.global.exception.error.CommonError;
 import com.moau.moau.user.domain.User;
 
-import java.lang.reflect.Field;
 import java.time.Instant;
 
 public class TeamMemberFactory {
@@ -17,35 +14,18 @@ public class TeamMemberFactory {
             TeamMemberStatus status,
             Long updatedBy
     ) {
-
-        TeamMember member = new TeamMember();
-        TeamMemberId id = new TeamMemberId();
         Instant now = Instant.now();
+        TeamMemberId id = new TeamMemberId(team.getId(), user.getId());
 
-        // 복합키 설정
-        setField(id, "teamId", team.getId());
-        setField(id, "userId", user.getId());
-
-        // TeamMember 필드 설정
-        setField(member, "id", id);
-        setField(member, "team", team);
-        setField(member, "user", user);
-        setField(member, "role", role);
-        setField(member, "status", status);
-        setField(member, "joinedAt", now);
-        setField(member, "updatedAt", now);
-        setField(member, "updatedBy", updatedBy);
-
-        return member;
-    }
-
-    private static void setField(Object target, String fieldName, Object value) {
-        try {
-            Field field = target.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(target, value);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new BusinessException(CommonError.TEAM_MEMBER_FIELD_ERROR, null, e);
-        }
+        return TeamMember.builder()
+                .id(id)
+                .team(team)
+                .user(user)
+                .role(role)
+                .status(status)
+                .joinedAt(now)
+                .updatedAt(now)
+                .updatedBy(updatedBy)
+                .build();
     }
 }

--- a/src/main/java/com/moau/moau/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/moau/moau/team/repository/TeamMemberRepository.java
@@ -18,6 +18,12 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemb
 
     List<TeamMember> findByUserId(Long userId);
 
+    /**
+     * N+1 쿼리 방지: Team과 함께 조회
+     */
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.id.userId = :userId")
+    List<TeamMember> findByUserIdWithTeam(Long userId);
+
     List<TeamMember> findAllByTeam(Team team);
 
     Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);

--- a/src/main/java/com/moau/moau/user/repository/UserRepository.java
+++ b/src/main/java/com/moau/moau/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ package com.moau.moau.user.repository;
 import com.moau.moau.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,4 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // soft delete 안 된 유저만 조회
     Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
+    // N+1 쿼리 방지: 여러 유저 일괄 조회
+    List<User> findAllByIdIn(Collection<Long> ids);
 }


### PR DESCRIPTION
## Included branches
- refactor/1-team-member-factory-builder
- refactor/2-join-request-factory-domain-method
- refactor/3-exception-handler-logging
- refactor/4-team-join-approve-dry
- refactor/11-banking-duplicate-code
- refactor/12-receipt-review-state
- refactor/13-dues-member-optimistic-lock
- refactor/16-receipt-review-n-plus-1
- refactor/20-notice-query-n-plus-1
- refactor/21-notice-poll-n-plus-1
- refactor/23-poll-race-condition
- refactor/24-schedule-n-plus-1
- fix/8-post-comment-count-race
- refactor/19-comment-lazy-loading
- feature/14-dues-event-sourcing

## Review summary
Excluded branches with blocking issues:
- fix/10-banking-balance-race: JPQL query uses `LIMIT 1`, which is invalid in JPQL
- fix/6-banking-race-condition: optimistic lock does not protect append-only `BankBalance` inserts
- refactor/15-dues-n-plus-1: user-facing transaction description regresses from nickname to raw user id
- refactor/17-receipt-command-user: API response regresses `uploaderName` to null
- refactor/18-post-query-n-plus-1: includes refactor/9 behavioral change removing explicit team existence validation
- refactor/9-post-command-remove-exists: changes nonexistent-team behavior / auth semantics
- refactor/5-kakao-auth-validation: invalid token request response contract changes via generic Bean Validation
- feature/15-ocr-monitoring: retries run inside transactional flow and hold DB transaction across external waits

## Verification
- `./gradlew test` still fails on base `develop` and this branch with the same AWS SDK bean creation error in `MoauApplicationTests.contextLoads()`
- compile/test classes completed before the shared context startup failure
